### PR TITLE
update foregroundcolor for highlighted cursor

### DIFF
--- a/examples/themes/dracula.yaml
+++ b/examples/themes/dracula.yaml
@@ -7,7 +7,7 @@ k9s:
     fg: "#f8f8f2"      # Dracula foreground
     bg: "#282a36"      # Dracula background
     logo: "#bd93f9"    # Dracula purple
-  
+
   frame:
     border:
       fg: "#6272a4"    # Dracula comment (softer)
@@ -27,13 +27,13 @@ k9s:
     title:
       fg: "#f8f8f2"
       bg: "#282a36"
-  
+
   views:
     table:
       fg: "#f8f8f2"
       bg: "#282a36"
       cursor:
-        fg: "#282a36"
+        fg: "#ff79c6"
         bg: "#bd93f9"  # Dracula purple for selection
       header:
         fg: "#8be9fd"  # Dracula cyan
@@ -45,5 +45,3 @@ k9s:
     logs:
       fg: "#f8f8f2"
       bg: "#282a36"
-
-


### PR DESCRIPTION
The highlighted text isn't great as it make the text more difficult to read. Thoughts on updating to this?

# Current
<img width="1629" height="178" alt="image" src="https://github.com/user-attachments/assets/7d5152c4-669d-4382-b979-c072224b86f2" />


# Updated
<img width="1911" height="162" alt="image" src="https://github.com/user-attachments/assets/17efdb23-cfb2-43a3-a8e7-3b0e6f76857f" />
