### PR TITLE
Skin improvements, cli enhance, scrolling bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,6 +382,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "csscolorparser"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda6aace1fbef3aa217b27f4c8d7d071ef2a70a5ca51050b1f17d40299d3f16"
+dependencies = [
+ "phf",
+]
+
+[[package]]
 name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,6 +595,7 @@ dependencies = [
  "chrono",
  "clap",
  "crossterm 0.28.1",
+ "csscolorparser",
  "directories",
  "futures",
  "k8s-openapi",
@@ -1612,6 +1622,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1707,6 +1759,21 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "ratatui"
@@ -2008,6 +2075,12 @@ checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ chrono = { version = "0.4", features = ["serde"] }
 url = "2.5"
 tempfile = "3.10"
 directories = "5.0"
+csscolorparser = "0.7"
 
 # CLI argument parsing
 clap = { version = "4.5", features = ["derive"] }

--- a/src/config/loader.rs
+++ b/src/config/loader.rs
@@ -117,6 +117,7 @@ impl ConfigLoader {
                 headless: other.ui.headless,
                 no_icons: other.ui.no_icons,
                 skin: other.ui.skin.clone(),
+                skin_read_only: other.ui.skin_read_only.clone(),
                 splashless: other.ui.splashless,
             },
             logger: LoggerConfig {
@@ -126,6 +127,7 @@ impl ConfigLoader {
                 text_wrap: other.logger.text_wrap,
             },
             namespace_hotkeys: other.namespace_hotkeys.clone(),
+            context_skins: other.context_skins.clone(),
             cluster: other.cluster,
         }
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -27,6 +27,7 @@ pub fn get_config_value(config: &schema::Config, key: &str) -> anyhow::Result<St
         "ui.headless" => Ok(config.ui.headless.to_string()),
         "ui.noIcons" => Ok(config.ui.no_icons.to_string()),
         "ui.skin" => Ok(config.ui.skin.clone()),
+        "ui.skinReadOnly" => Ok(config.ui.skin_read_only.clone().unwrap_or_default()),
         "ui.splashless" => Ok(config.ui.splashless.to_string()),
         "logger.tail" => Ok(config.logger.tail.to_string()),
         "logger.buffer" => Ok(config.logger.buffer.to_string()),
@@ -70,6 +71,13 @@ pub fn set_config_value(config: &mut schema::Config, key: &str, value: &str) -> 
         }
         "ui.skin" => {
             config.ui.skin = value.to_string();
+        }
+        "ui.skinReadOnly" => {
+            if value.is_empty() {
+                config.ui.skin_read_only = None;
+            } else {
+                config.ui.skin_read_only = Some(value.to_string());
+            }
         }
         "ui.splashless" => {
             config.ui.splashless = value

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -31,6 +31,11 @@ pub struct Config {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub namespace_hotkeys: Vec<String>,
 
+    /// Context-specific skin configuration
+    /// Map of context name to skin name
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub context_skins: HashMap<String, String>,
+
     /// Cluster-specific settings (merged with cluster configs)
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub cluster: HashMap<String, serde_yaml::Value>,
@@ -52,9 +57,13 @@ pub struct UiConfig {
     #[serde(default = "default_false")]
     pub no_icons: bool,
 
-    /// Default theme name
+    /// Default skin name
     #[serde(default = "default_skin")]
     pub skin: String,
+
+    /// Skin name for readonly mode (overrides skin when readOnly=true)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skin_read_only: Option<String>,
 
     /// Skip startup splash screen
     #[serde(default = "default_false")]
@@ -123,6 +132,7 @@ impl Default for Config {
             ui: UiConfig::default(),
             logger: LoggerConfig::default(),
             namespace_hotkeys: Vec::new(), // Empty means use auto-discovered defaults
+            context_skins: HashMap::new(),
             cluster: HashMap::new(),
         }
     }
@@ -135,6 +145,7 @@ impl Default for UiConfig {
             headless: default_false(),
             no_icons: default_false(),
             skin: default_skin(),
+            skin_read_only: None,
             splashless: default_false(),
         }
     }

--- a/src/config/theme_loader.rs
+++ b/src/config/theme_loader.rs
@@ -5,9 +5,11 @@
 use super::paths;
 use crate::tui::Theme;
 use anyhow::{Context, Result};
+use csscolorparser::Color as CssColor;
 use ratatui::style::Color;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use std::str::FromStr;
 
 /// k9s-style skin file structure
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -145,38 +147,165 @@ struct LogsColors {
 pub struct ThemeLoader;
 
 impl ThemeLoader {
-    /// Load a theme by name
+    /// Load a skin by name
     ///
     /// Resolution order:
-    /// 1. User skins directory ($XDG_DATA_HOME/flux9s/skins/{name}.yaml)
-    /// 2. System skins directory ($XDG_CONFIG_HOME/flux9s/skins/{name}.yaml)
-    /// 3. Built-in default theme
+    /// 1. Config skins directory ($XDG_CONFIG_HOME/flux9s/skins/{name}.yaml) - user-installed skins
+    /// 2. Data skins directory ($XDG_DATA_HOME/flux9s/skins/{name}.yaml) - legacy location
+    /// 3. Built-in default skin
     pub fn load_theme(name: &str) -> Result<Theme> {
-        // Try user skins directory first
-        let user_skin_path = paths::user_skins_dir().join(format!("{}.yaml", name));
-        if user_skin_path.exists() {
-            return Self::load_from_file(&user_skin_path);
+        // Try config skins directory first (where user-installed skins go)
+        let config_skin_path = paths::skins_dir().join(format!("{}.yaml", name));
+        if config_skin_path.exists() {
+            return Self::load_from_file(&config_skin_path);
         }
 
-        // Try system skins directory
-        let system_skin_path = paths::skins_dir().join(format!("{}.yaml", name));
-        if system_skin_path.exists() {
-            return Self::load_from_file(&system_skin_path);
+        // Try data skins directory (legacy location)
+        let data_skin_path = paths::user_skins_dir().join(format!("{}.yaml", name));
+        if data_skin_path.exists() {
+            return Self::load_from_file(&data_skin_path);
         }
 
-        // Fall back to default theme
+        // Fall back to default skin
         if name == "default" {
             return Ok(Theme::default());
         }
 
         Err(anyhow::anyhow!(
-            "Theme '{}' not found in either \n '{}'\n  or '{}'",
+            "Skin '{}' not found in either \n '{}'\n  or '{}'",
             name,
+            paths::skins_dir().join(format!("{}.yaml", name)).display(),
             paths::user_skins_dir()
                 .join(format!("{}.yaml", name))
-                .display(),
-            paths::skins_dir().join(format!("{}.yaml", name)).display()
+                .display()
         ))
+    }
+
+    /// Install a skin from a YAML file
+    ///
+    /// Validates the skin file and copies it to the config skins directory.
+    /// The skin name is derived from the source filename (without .yaml extension).
+    pub fn install_theme(source_path: &std::path::Path) -> Result<String> {
+        use std::fs;
+
+        // Check if source file exists
+        if !source_path.exists() {
+            return Err(anyhow::anyhow!(
+                "Skin file not found: {}",
+                source_path.display()
+            ));
+        }
+
+        // Extract skin name from filename
+        let skin_name = source_path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .ok_or_else(|| anyhow::anyhow!("Invalid filename: {}", source_path.display()))?;
+
+        if skin_name.is_empty() {
+            return Err(anyhow::anyhow!("Skin name cannot be empty"));
+        }
+
+        println!("Validating skin file: {}", source_path.display());
+
+        // Read and validate the skin file
+        let contents = fs::read_to_string(source_path)
+            .with_context(|| format!("Failed to read skin file: {}", source_path.display()))?;
+
+        // Parse YAML
+        let skin: SkinFile = serde_yaml::from_str(&contents)
+            .with_context(|| format!("Failed to parse YAML: {}", source_path.display()))?;
+
+        // Validate skin structure
+        Self::validate_theme_structure(&skin).with_context(|| "Skin validation failed")?;
+
+        // Try to convert to Theme to validate colors can be parsed
+        Self::convert_skin_to_theme(skin.clone())
+            .with_context(|| "Failed to convert skin - invalid color values")?;
+
+        println!("✓ Skin validation passed");
+
+        // Ensure skins directory exists (in config directory)
+        let skins_dir = paths::skins_dir();
+        paths::ensure_dir(&skins_dir).with_context(|| {
+            format!("Failed to create skins directory: {}", skins_dir.display())
+        })?;
+
+        // Determine destination path
+        let dest_path = skins_dir.join(format!("{}.yaml", skin_name));
+
+        // Check if skin already exists
+        if dest_path.exists() {
+            println!(
+                "Warning: Skin '{}' already exists and will be overwritten",
+                skin_name
+            );
+        }
+
+        // Copy file to skins directory
+        fs::copy(source_path, &dest_path)
+            .with_context(|| format!("Failed to copy skin file to: {}", dest_path.display()))?;
+
+        println!("✓ Skin '{}' installed successfully", skin_name);
+        println!("  Location: {}", dest_path.display());
+
+        // Return the skin name so caller can set it in config
+        Ok(skin_name.to_string())
+    }
+
+    /// Validate skin structure - check for required keys and structure
+    fn validate_theme_structure(skin: &SkinFile) -> Result<()> {
+        // Check that k9s key exists
+        let k9s = skin
+            .k9s
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("Missing required 'k9s' key in skin file"))?;
+
+        // Check for at least some color definitions
+        let mut has_colors = false;
+
+        // Check body colors
+        if let Some(body) = &k9s.body {
+            if body.fg.is_some() || body.bg.is_some() || body.logo.is_some() {
+                has_colors = true;
+            }
+        }
+
+        // Check frame colors
+        if let Some(frame) = &k9s.frame {
+            if frame.border.is_some()
+                || frame.menu.is_some()
+                || frame.crumbs.is_some()
+                || frame.status.is_some()
+                || frame.title.is_some()
+            {
+                has_colors = true;
+            }
+        }
+
+        // Check view colors
+        if let Some(views) = &k9s.views {
+            if views.table.is_some() || views.yaml.is_some() || views.logs.is_some() {
+                has_colors = true;
+            }
+        }
+
+        if !has_colors {
+            return Err(anyhow::anyhow!(
+                "Skin file must contain at least one color definition.\n\
+                 Expected structure:\n\
+                 k9s:\n\
+                   body:\n\
+                     fgColor: <color>\n\
+                   views:\n\
+                     table:\n\
+                       cursor:\n\
+                         fgColor: <color>\n\
+                         bgColor: <color>"
+            ));
+        }
+
+        Ok(())
     }
 
     /// Load theme from a YAML file
@@ -288,6 +417,10 @@ impl ThemeLoader {
                             theme.table_selected = parse_color(&fg)?;
                             colors_applied += 1;
                         }
+                        if let Some(bg) = cursor.bg {
+                            theme.table_selected_bg = parse_color(&bg)?;
+                            colors_applied += 1;
+                        }
                     }
                     if let Some(header) = table.header {
                         if let Some(fg) = header.fg {
@@ -321,29 +454,29 @@ impl ThemeLoader {
         Ok(theme)
     }
 
-    /// List available themes
+    /// List available skins
     pub fn list_themes() -> Vec<String> {
-        let mut themes = Vec::new();
+        let mut skins = Vec::new();
 
-        // Check user skins directory
-        if let Ok(entries) = std::fs::read_dir(paths::user_skins_dir()) {
+        // Check config skins directory first (where user-installed skins go)
+        if let Ok(entries) = std::fs::read_dir(paths::skins_dir()) {
             for entry in entries.flatten() {
                 if let Some(name) = entry.file_name().to_str() {
                     if name.ends_with(".yaml") {
-                        themes.push(name.trim_end_matches(".yaml").to_string());
+                        skins.push(name.trim_end_matches(".yaml").to_string());
                     }
                 }
             }
         }
 
-        // Check system skins directory
-        if let Ok(entries) = std::fs::read_dir(paths::skins_dir()) {
+        // Check data skins directory (legacy location)
+        if let Ok(entries) = std::fs::read_dir(paths::user_skins_dir()) {
             for entry in entries.flatten() {
                 if let Some(name) = entry.file_name().to_str() {
                     if name.ends_with(".yaml") {
-                        let theme_name = name.trim_end_matches(".yaml").to_string();
-                        if !themes.contains(&theme_name) {
-                            themes.push(theme_name);
+                        let skin_name = name.trim_end_matches(".yaml").to_string();
+                        if !skins.contains(&skin_name) {
+                            skins.push(skin_name);
                         }
                     }
                 }
@@ -351,88 +484,62 @@ impl ThemeLoader {
         }
 
         // Always include default
-        if !themes.contains(&"default".to_string()) {
-            themes.insert(0, "default".to_string());
+        if !skins.contains(&"default".to_string()) {
+            skins.insert(0, "default".to_string());
         }
 
-        themes.sort();
-        themes
+        skins.sort();
+        skins
     }
 }
 
 /// Parse a color string to ratatui Color
 ///
 /// Supports:
-/// - Hex colors: #ffffff, #fff
-/// - Named colors: white, black, red, green, blue, yellow, cyan, magenta
+/// - Hex colors: #ffffff, #fff, ffffff, fff
+/// - Named colors: CSS Color Module Level 4 names (140+ colors including X11 colors)
 /// - Special: "default" returns a default color
+///
+/// Uses csscolorparser crate for comprehensive color name support.
 fn parse_color(color_str: &str) -> Result<Color> {
-    let color_str = color_str.trim().to_lowercase();
+    let color_str = color_str.trim();
 
     // Handle "default" special case
-    if color_str == "default" {
+    if color_str.eq_ignore_ascii_case("default") {
         return Ok(Color::Reset);
     }
 
-    // Handle hex colors
-    if color_str.starts_with('#') {
-        return parse_hex_color(&color_str);
+    // Use csscolorparser to parse the color string
+    // It handles hex colors (with/without #), CSS named colors, rgb(), rgba(), hsl(), etc.
+    let css_color = CssColor::from_str(color_str)
+        .map_err(|e| anyhow::anyhow!("Invalid color '{}': {}", color_str, e))?;
+
+    // Convert csscolorparser Color to ratatui Color
+    // csscolorparser uses f64 for components (0.0-1.0), convert to u8 (0-255)
+    let rgba = css_color.to_rgba8();
+    let (r, g, b) = (rgba[0], rgba[1], rgba[2]);
+
+    // Map common colors to ratatui's built-in colors for better terminal compatibility
+    // This helps with terminals that don't support 24-bit color
+    match (r, g, b) {
+        (0, 0, 0) => Ok(Color::Black),
+        (128, 0, 0) => Ok(Color::Red),            // darkred -> Red
+        (0, 128, 0) => Ok(Color::Green),          // darkgreen -> Green
+        (128, 128, 0) => Ok(Color::Yellow),       // darkyellow -> Yellow
+        (0, 0, 128) => Ok(Color::Blue),           // darkblue -> Blue
+        (128, 0, 128) => Ok(Color::Magenta),      // darkmagenta -> Magenta
+        (0, 128, 128) => Ok(Color::Cyan),         // darkcyan -> Cyan
+        (192, 192, 192) => Ok(Color::Gray),       // silver -> Gray
+        (128, 128, 128) => Ok(Color::DarkGray),   // gray -> DarkGray
+        (255, 0, 0) => Ok(Color::LightRed),       // red -> LightRed
+        (0, 255, 0) => Ok(Color::LightGreen),     // lime -> LightGreen
+        (255, 255, 0) => Ok(Color::LightYellow),  // yellow -> LightYellow
+        (0, 0, 255) => Ok(Color::LightBlue),      // blue -> LightBlue
+        (255, 0, 255) => Ok(Color::LightMagenta), // magenta -> LightMagenta
+        (0, 255, 255) => Ok(Color::LightCyan),    // cyan/aqua -> LightCyan
+        (255, 255, 255) => Ok(Color::White),
+        _ => Ok(Color::Rgb(r, g, b)), // Use RGB for all other colors
     }
-
-    // Handle named colors
-    match color_str.as_str() {
-        "black" => Ok(Color::Black),
-        "red" => Ok(Color::Red),
-        "green" => Ok(Color::Green),
-        "yellow" => Ok(Color::Yellow),
-        "blue" => Ok(Color::Blue),
-        "magenta" => Ok(Color::Magenta),
-        "cyan" => Ok(Color::Cyan),
-        "white" => Ok(Color::White),
-        "gray" | "grey" => Ok(Color::Gray),
-        "darkgray" | "darkgrey" => Ok(Color::DarkGray),
-        "lightred" => Ok(Color::LightRed),
-        "lightgreen" => Ok(Color::LightGreen),
-        "lightyellow" => Ok(Color::LightYellow),
-        "lightblue" => Ok(Color::LightBlue),
-        "lightmagenta" => Ok(Color::LightMagenta),
-        "lightcyan" => Ok(Color::LightCyan),
-        _ => {
-            // Try parsing as hex without #
-            if color_str.len() == 6 || color_str.len() == 3 {
-                parse_hex_color(&format!("#{}", color_str))
-            } else {
-                Err(anyhow::anyhow!("Unknown color: {}", color_str))
-            }
-        }
-    }
-}
-
-/// Parse hex color string (#RRGGBB or #RGB)
-fn parse_hex_color(hex: &str) -> Result<Color> {
-    let hex = hex.trim_start_matches('#');
-    let (r, g, b) = if hex.len() == 6 {
-        let r = u8::from_str_radix(&hex[0..2], 16)
-            .map_err(|_| anyhow::anyhow!("Invalid hex color: {}", hex))?;
-        let g = u8::from_str_radix(&hex[2..4], 16)
-            .map_err(|_| anyhow::anyhow!("Invalid hex color: {}", hex))?;
-        let b = u8::from_str_radix(&hex[4..6], 16)
-            .map_err(|_| anyhow::anyhow!("Invalid hex color: {}", hex))?;
-        (r, g, b)
-    } else if hex.len() == 3 {
-        let r = u8::from_str_radix(&hex[0..1], 16)
-            .map_err(|_| anyhow::anyhow!("Invalid hex color: {}", hex))?;
-        let g = u8::from_str_radix(&hex[1..2], 16)
-            .map_err(|_| anyhow::anyhow!("Invalid hex color: {}", hex))?;
-        let b = u8::from_str_radix(&hex[2..3], 16)
-            .map_err(|_| anyhow::anyhow!("Invalid hex color: {}", hex))?;
-        // Expand short hex: #abc -> #aabbcc
-        (r * 17, g * 17, b * 17)
-    } else {
-        return Err(anyhow::anyhow!("Invalid hex color length: {}", hex));
-    };
-
-    Ok(Color::Rgb(r, g, b))
 }
 
 #[cfg(test)]
@@ -441,32 +548,101 @@ mod tests {
 
     #[test]
     fn test_parse_named_colors() {
-        assert_eq!(parse_color("red").unwrap(), Color::Red);
+        // Basic colors - csscolorparser maps these to RGB values
+        // "red" is RGB(255,0,0) which maps to LightRed
+        assert_eq!(parse_color("red").unwrap(), Color::LightRed);
+        // "green" is RGB(0,128,0) which maps to Green
         assert_eq!(parse_color("green").unwrap(), Color::Green);
-        assert_eq!(parse_color("blue").unwrap(), Color::Blue);
+        // "blue" is RGB(0,0,255) which maps to LightBlue
+        assert_eq!(parse_color("blue").unwrap(), Color::LightBlue);
+        // "black" maps to Black
+        assert_eq!(parse_color("black").unwrap(), Color::Black);
+        // "white" maps to White
+        assert_eq!(parse_color("white").unwrap(), Color::White);
+    }
+
+    #[test]
+    fn test_parse_extended_color_names() {
+        // Test extended CSS/X11 color names that csscolorparser supports
+        let dodgerblue = parse_color("dodgerblue").unwrap();
+        if let Color::Rgb(r, g, b) = dodgerblue {
+            assert_eq!(r, 30);
+            assert_eq!(g, 144);
+            assert_eq!(b, 255);
+        } else {
+            panic!("Expected Rgb color for dodgerblue");
+        }
+
+        let steelblue = parse_color("steelblue").unwrap();
+        if let Color::Rgb(r, g, b) = steelblue {
+            assert_eq!(r, 70);
+            assert_eq!(g, 130);
+            assert_eq!(b, 180);
+        } else {
+            panic!("Expected Rgb color for steelblue");
+        }
     }
 
     #[test]
     fn test_parse_hex_colors() {
+        // Pure red (#ff0000) maps to LightRed based on our color mapping
         let color = parse_color("#ff0000").unwrap();
+        assert_eq!(color, Color::LightRed);
+
+        // Test a color that doesn't map to a built-in color
+        let color = parse_color("#123456").unwrap();
         if let Color::Rgb(r, g, b) = color {
-            assert_eq!(r, 255);
-            assert_eq!(g, 0);
-            assert_eq!(b, 0);
+            assert_eq!(r, 0x12);
+            assert_eq!(g, 0x34);
+            assert_eq!(b, 0x56);
         } else {
-            panic!("Expected Rgb color");
+            panic!("Expected Rgb color for #123456");
         }
     }
 
     #[test]
     fn test_parse_short_hex() {
+        // Short hex #f00 expands to #ff0000 which maps to LightRed
         let color = parse_color("#f00").unwrap();
+        assert_eq!(color, Color::LightRed);
+
+        // Test a color that doesn't map to a built-in color
+        let color = parse_color("#abc").unwrap();
         if let Color::Rgb(r, g, b) = color {
-            assert_eq!(r, 255);
-            assert_eq!(g, 0);
-            assert_eq!(b, 0);
+            assert_eq!(r, 0xaa);
+            assert_eq!(g, 0xbb);
+            assert_eq!(b, 0xcc);
         } else {
-            panic!("Expected Rgb color");
+            panic!("Expected Rgb color for #abc");
         }
+    }
+
+    #[test]
+    fn test_parse_hex_without_hash() {
+        // Hex without hash also works
+        let color = parse_color("ff0000").unwrap();
+        assert_eq!(color, Color::LightRed);
+
+        // Test a color that doesn't map to a built-in color
+        let color = parse_color("123456").unwrap();
+        if let Color::Rgb(r, g, b) = color {
+            assert_eq!(r, 0x12);
+            assert_eq!(g, 0x34);
+            assert_eq!(b, 0x56);
+        } else {
+            panic!("Expected Rgb color for 123456");
+        }
+    }
+
+    #[test]
+    fn test_parse_default() {
+        assert_eq!(parse_color("default").unwrap(), Color::Reset);
+        assert_eq!(parse_color("DEFAULT").unwrap(), Color::Reset);
+    }
+
+    #[test]
+    fn test_parse_invalid_color() {
+        assert!(parse_color("notacolor").is_err());
+        assert!(parse_color("#gggggg").is_err());
     }
 }

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -30,6 +30,7 @@ pub struct Theme {
     // Table colors
     pub table_header: Color,
     pub table_selected: Color,
+    pub table_selected_bg: Color, // Background color for selected row
     pub table_normal: Color,
 
     // Text colors
@@ -78,6 +79,7 @@ impl Default for Theme {
             // Table colors
             table_header: Color::Cyan,
             table_selected: Color::Blue,
+            table_selected_bg: Color::DarkGray, // Dark gray background for selected row
             table_normal: Color::White,
 
             // Text colors
@@ -137,7 +139,9 @@ impl Theme {
     }
 
     pub fn table_selected_style(&self) -> Style {
-        Style::default().fg(self.table_selected)
+        Style::default()
+            .fg(self.table_selected)
+            .bg(self.table_selected_bg)
     }
 
     pub fn footer_key_style(&self) -> Style {

--- a/src/tui/views/resource_list.rs
+++ b/src/tui/views/resource_list.rs
@@ -27,13 +27,17 @@ pub fn render_resource_list(
     no_icons: bool,
 ) {
     let visible_height = (area.height as usize).saturating_sub(2);
+    const SCROLL_BUFFER: usize = 2; // Keep 2 rows buffer before scrolling
 
-    // Adjust scroll offset based on selected index
-    if selected_index >= *scroll_offset + visible_height {
-        *scroll_offset = selected_index.saturating_sub(visible_height - 1);
+    // Adjust scroll offset based on selected index with buffer
+    // When selected row is near bottom, scroll to keep buffer
+    if selected_index >= *scroll_offset + visible_height.saturating_sub(SCROLL_BUFFER) {
+        *scroll_offset =
+            selected_index.saturating_sub(visible_height.saturating_sub(SCROLL_BUFFER + 1));
     }
-    if selected_index < *scroll_offset {
-        *scroll_offset = selected_index;
+    // When selected row is above visible area, scroll to show it with buffer
+    if selected_index < *scroll_offset + SCROLL_BUFFER {
+        *scroll_offset = selected_index.saturating_sub(SCROLL_BUFFER);
     }
 
     // Ensure selected_index is valid


### PR DESCRIPTION
## Summary of Changes

This branch implements several UI improvements to enhance the user experience and visual clarity of flux9s.

 **YAML syntax highlighting** has been added with kubecolor-like colorization, where keys are displayed in cyan, strings in green, numbers and booleans in yellow, and null values in red, making it easier to scan and understand YAML output. 

**Scrolling behaviour** has been improved with a 2-row buffer system that ensures the selected row remains visible when navigating through long resource lists, preventing the cursor from disappearing off-screen. The **header display** has been cleaned up to show "Resources:" only once on the first line, with subsequent resource types wrapping properly across multiple lines instead of repeating the label.

 **Background colour support** for the selected row cursor has been implemented, and now using `csscolourparser` crate for more theme flexibility. 
 
 **CLI Changes** - `flux9s config skins` now has skin subcommands, and `flux9s config list / set` has more features added. 

Closes #55 