### PR TITLE
graph rework - command handler

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,19 @@ source of truth and prevents inconsistencies when Flux versions change.
 4. Add to help text (`src/tui/views/help.rs`)
 5. Write operation tests
 
+### Adding a Command
+
+`:` commands are dispatched from a data-driven table, not a long `if`/`match` chain.
+
+1. Add a focused `cmd_<name>(&mut self, cmd: &str)` handler on `App` (`src/tui/app/events.rs`)
+2. Add a predicate in `src/tui/commands.rs` (e.g. `is_<name>_command`)
+3. Register the `(predicate, handler)` pair in `COMMAND_TABLE` at the top of `events.rs`
+4. Update help text (`src/tui/views/help.rs`) and the docs site
+5. Write a test that drives `execute_command()` (see the `events.rs` test module)
+
+Special commands handled directly in `execute_command` (help/quit/readonly and the
+connection-error gate) and the resource-type fallback stay outside the table.
+
 ### View Components
 
 - Keep views stateless - they receive all needed data as parameters
@@ -106,6 +119,10 @@ source of truth and prevents inconsistencies when Flux versions change.
 - Submenu overlays render as centered popups on top of the current view
 - State management for submenus lives in `ViewState.submenu_state`
 - Event handling priority: confirmation → submenu → filter → normal commands
+- Per-view behavior is consolidated on `impl View` (`src/tui/app/state.rs`):
+  `scroll_offset_mut`, `is_list_view`, `is_text_search_view`, `is_nested_view`.
+  Add a new view's scroll/back/classification there instead of scattering
+  `match current_view` arms across the event handlers.
 
 ## Testing Requirements
 
@@ -205,3 +222,4 @@ Commands can provide interactive selection menus using the `CommandSubmenu` trai
 - Update both `NO_PROXY` and `no_proxy` for environment compatibility
 - Generated models are version-controlled for reproducible builds
 - **Never hardcode Flux resource types, API groups, versions, or plural names** - always use `FluxResourceKind` enum and `get_gvk_for_resource_type()` helper function to ensure single source of truth
+- **Graph node dimensions have one source of truth**: `GraphNode::render_width`/`render_height` (`src/trace/graph.rs`). Both layout (`calculate_layout`) and drawing (`src/tui/views/graph.rs`) call them - never recompute node size inline. Connector geometry is produced by the pure, `Frame`-free `fanout_routes()` so it can be unit tested, separate from the drawing pass.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Graph view keyboard navigation: `j`/`k` move a highlighted focus between nodes
+  (the view auto-scrolls to keep it visible), `Enter` opens the focused resource's
+  detail view, and `Esc` returns to the graph.
+
+### Changed
+- Graph connectors are redrawn as consistent fan-outs (trunk → branch above the
+  children → drop into each child) using proper box-drawing junctions, and nodes
+  sit closer together for a tighter, clearer layout.
+
+### Internal
+- Single source of truth for graph node sizing (`GraphNode::render_width`/
+  `render_height`); connector geometry extracted into the testable, `Frame`-free
+  `fanout_routes()`.
+- Per-view behavior consolidated onto `impl View` helpers (`scroll_offset_mut`,
+  `is_list_view`, `is_text_search_view`, `is_nested_view`).
+- `:` command handling is now data-driven via `COMMAND_TABLE` with focused
+  `cmd_*` handlers, replacing the long string-matching chain in `execute_command`.
+
 ## [0.10.2] - 2026-06-21
 
 ### Changes\n- Version bump to 0.10.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,19 @@ source of truth and prevents inconsistencies when Flux versions change.
 4. Add to help text (`src/tui/views/help.rs`)
 5. Write operation tests
 
+### Adding a Command
+
+`:` commands are dispatched from a data-driven table, not a long `if`/`match` chain.
+
+1. Add a focused `cmd_<name>(&mut self, cmd: &str)` handler on `App` (`src/tui/app/events.rs`)
+2. Add a predicate in `src/tui/commands.rs` (e.g. `is_<name>_command`)
+3. Register the `(predicate, handler)` pair in `COMMAND_TABLE` at the top of `events.rs`
+4. Update help text (`src/tui/views/help.rs`) and the docs site
+5. Write a test that drives `execute_command()` (see the `events.rs` test module)
+
+Special commands handled directly in `execute_command` (help/quit/readonly and the
+connection-error gate) and the resource-type fallback stay outside the table.
+
 ### View Components
 
 - Keep views stateless - they receive all needed data as parameters
@@ -106,6 +119,10 @@ source of truth and prevents inconsistencies when Flux versions change.
 - Submenu overlays render as centered popups on top of the current view
 - State management for submenus lives in `ViewState.submenu_state`
 - Event handling priority: confirmation → submenu → filter → normal commands
+- Per-view behavior is consolidated on `impl View` (`src/tui/app/state.rs`):
+  `scroll_offset_mut`, `is_list_view`, `is_text_search_view`, `is_nested_view`.
+  Add a new view's scroll/back/classification there instead of scattering
+  `match current_view` arms across the event handlers.
 
 ## Testing Requirements
 
@@ -205,3 +222,4 @@ Commands can provide interactive selection menus using the `CommandSubmenu` trai
 - Update both `NO_PROXY` and `no_proxy` for environment compatibility
 - Generated models are version-controlled for reproducible builds
 - **Never hardcode Flux resource types, API groups, versions, or plural names** - always use `FluxResourceKind` enum and `get_gvk_for_resource_type()` helper function to ensure single source of truth
+- **Graph node dimensions have one source of truth**: `GraphNode::render_width`/`render_height` (`src/trace/graph.rs`). Both layout (`calculate_layout`) and drawing (`src/tui/views/graph.rs`) call them - never recompute node size inline. Connector geometry is produced by the pure, `Frame`-free `fanout_routes()` so it can be unit tested, separate from the drawing pass.

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -139,10 +139,18 @@ Terminal user interface built with ratatui.
 - Non-blocking async operations using `tokio::spawn`
 - Modular app structure with separated concerns (state, events, rendering, async)
 - Separate scroll offsets for different views
+- Per-view behavior (scroll target, back navigation, classification) lives on
+  `impl View` (`src/tui/app/state.rs`) rather than scattered `match` arms
 - Dynamic footer wrapping for smaller screens
 - Extensible operation system via trait-based design
-- Command mode with autocomplete support
+- Command mode with autocomplete support; `:` commands dispatch through a
+  data-driven `COMMAND_TABLE` of `(predicate, handler)` pairs in `events.rs`
 - Interactive submenu overlays for command selection
+- Graph view separates pure layout/geometry from drawing: node sizing lives on
+  `GraphNode::render_width`/`render_height`, and connector routing is computed by
+  the `Frame`-free `fanout_routes()` so it can be unit tested
+- Graph view supports keyboard focus navigation (`j`/`k` move focus, `Enter`
+  opens the focused node, `Esc` returns to the graph)
 
 #### 3. Models Module (`src/models/`)
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ By default, `flux9s` watches the `flux-system` namespace. Use `:ns all` to view 
 
 ### Resource Views
 
-- **Graph View (`g`)** - Visualize resource relationships and dependencies. Shows upstream sources and downstream managed resources. Supported for Kustomization, HelmRelease, ArtifactGenerator, FluxInstance, and ResourceSet.
+- **Graph View (`g`)** - Visualize resource relationships and dependencies. Shows upstream sources and downstream managed resources. Move the highlighted focus between nodes with `j`/`k` (the view scrolls to keep it visible), press `Enter` to open the focused resource's detail view, and `Esc` to return to the graph. Supported for Kustomization, HelmRelease, ArtifactGenerator, FluxInstance, and ResourceSet.
 - **History View (`h`)** - View reconciliation history for FluxInstance, ResourceSet, Kustomization, and HelmRelease resources.
 - **Favorites (`f`)** - Mark resources as favorites for quick access. Use `:favorites` command to view all favorites.
 

--- a/docs/content/user-guide/_index.md
+++ b/docs/content/user-guide/_index.md
@@ -215,6 +215,14 @@ The graph view displays:
 - **Resource groups** (aggregated by type)
 - **Workload groups** (aggregated workloads with status)
 
+**Navigating the graph:**
+
+- `j` / `k` (or `↓` / `↑`) - Move the highlighted focus between nodes; the view scrolls to keep the focused node visible.
+- `Enter` - Open the focused node's resource in the detail view. Aggregate nodes (workload/resource groups) and external upstream URLs aren't directly openable.
+- `Esc` / `Backspace` - Return to the graph (when you opened a detail view from it), then back to the resource list.
+
+Focus starts on the resource you opened the graph from, so you can immediately walk its sources and dependencies.
+
 ### Reconciliation History (`h`)
 
 View reconciliation history for resources that track it.

--- a/src/trace/graph.rs
+++ b/src/trace/graph.rs
@@ -5,6 +5,18 @@
 
 use std::collections::HashMap;
 
+/// Minimum rendered width of a graph node, in terminal columns.
+pub const MIN_NODE_WIDTH: u16 = 30;
+/// Maximum rendered width of a graph node, in terminal columns.
+pub const MAX_NODE_WIDTH: u16 = 60;
+/// Vertical gap (rows) between stacked nodes. Two is the minimum the fan-out edge
+/// routing needs: one row for the drop line and one for the horizontal branch.
+pub const NODE_VERTICAL_SPACING: u16 = 2;
+/// Horizontal gap (columns) between side-by-side inventory groups.
+pub const INVENTORY_GROUP_GAP: u16 = 4;
+/// Border + padding overhead reserved around a node's content, in columns.
+const NODE_HORIZONTAL_CHROME: u16 = 4;
+
 /// A node in the resource graph
 #[derive(Debug, Clone)]
 pub struct GraphNode {
@@ -24,6 +36,85 @@ pub struct GraphNode {
     pub position: Option<(u16, u16)>,
     /// Optional description/snippet about the resource (e.g., URL, path, etc.)
     pub description: Option<String>,
+}
+
+impl GraphNode {
+    /// Width of the widest line of content this node will render, in columns.
+    fn content_width(&self) -> u16 {
+        let desc = self
+            .description
+            .as_ref()
+            .map(|d| d.len() as u16)
+            .unwrap_or(0);
+        (self.name.len() as u16)
+            .max(self.kind.len() as u16)
+            .max(desc)
+    }
+
+    /// Rendered width in columns, clamped to sane bounds and the available width.
+    /// Single source of truth for node width across layout and drawing.
+    pub fn render_width(&self, available_width: u16) -> u16 {
+        self.content_width()
+            .clamp(MIN_NODE_WIDTH, MAX_NODE_WIDTH)
+            .min(available_width.saturating_sub(NODE_HORIZONTAL_CHROME))
+    }
+
+    /// Rendered height in rows: title section + content + borders. Single source
+    /// of truth for node height across layout and drawing.
+    pub fn render_height(&self) -> u16 {
+        // Group nodes show only a name + separator inside the borders (4 rows of
+        // chrome); other nodes also carry a kind label (5 rows).
+        let mut height = if matches!(
+            self.node_type,
+            NodeType::WorkloadGroup | NodeType::ResourceGroup
+        ) {
+            4
+        } else {
+            5
+        };
+
+        match self.node_type {
+            NodeType::Workload => {
+                if self.description.is_some() {
+                    height += 2; // description line + namespace subtitle
+                }
+            }
+            NodeType::WorkloadGroup => {
+                if let Some(desc) = &self.description {
+                    let lines: Vec<&str> = desc.lines().collect();
+                    let count = lines.len();
+                    if count > 0 {
+                        // A namespace line is shown per workload only when they differ.
+                        let show_namespace = count > 1 && {
+                            let first = lines[0].split('|').nth(2).unwrap_or("");
+                            !lines
+                                .iter()
+                                .all(|l| l.split('|').nth(2).unwrap_or("") == first)
+                        };
+                        let per_workload = if show_namespace { 4 } else { 3 };
+                        let blanks = count.saturating_sub(1);
+                        height += (count * per_workload + blanks) as u16;
+                    }
+                }
+            }
+            NodeType::ResourceGroup => {
+                if let Some(desc) = &self.description {
+                    // One line per resource kind ("Kind: count", joined by ", ").
+                    height += (desc.matches(", ").count() + 1) as u16;
+                }
+            }
+            _ => {
+                if self.description.is_some() {
+                    height += 1; // description line
+                }
+                if self.ready.is_some() {
+                    height += 1; // status line
+                }
+            }
+        }
+
+        height
+    }
 }
 
 /// Type of node in the graph
@@ -104,222 +195,140 @@ impl ResourceGraph {
         self.edges.push(edge);
     }
 
-    /// Calculate a simple hierarchical layout for the graph
-    /// Returns (width, height) needed for the layout
+    /// Vertical layer a node type occupies in the layout, used to order keyboard
+    /// focus from top to bottom (sources at the top, inventory at the bottom).
+    /// Mirrors the ordering applied in [`Self::calculate_layout`].
+    fn node_layer(node_type: NodeType) -> u8 {
+        match node_type {
+            NodeType::Upstream => 0,
+            NodeType::Source => 1,
+            NodeType::Chain => 2,
+            NodeType::Object => 3,
+            NodeType::FluxResource => 4,
+            NodeType::Workload | NodeType::WorkloadGroup => 5,
+            NodeType::ResourceGroup => 6,
+        }
+    }
+
+    /// Node indices in visual top-to-bottom order, used for keyboard focus
+    /// navigation. Within a layer, insertion order is preserved (stable sort).
+    pub fn focus_order(&self) -> Vec<usize> {
+        let mut order: Vec<usize> = (0..self.nodes.len()).collect();
+        order.sort_by_key(|&i| (Self::node_layer(self.nodes[i].node_type), i));
+        order
+    }
+
+    /// Index of the primary "object" node (the resource being viewed), if any.
+    /// Used as the initial focus target so the graph is navigable immediately.
+    pub fn object_node_index(&self) -> Option<usize> {
+        self.nodes
+            .iter()
+            .position(|n| n.node_type == NodeType::Object)
+    }
+
+    /// Position `indices` as a vertical, horizontally-centered stack starting at
+    /// `*current_y`, advancing `*current_y` past the placed nodes.
+    fn stack_centered(
+        &mut self,
+        indices: &[usize],
+        available_width: u16,
+        center_x: u16,
+        current_y: &mut u16,
+    ) {
+        for &idx in indices {
+            if let Some(node) = self.nodes.get_mut(idx) {
+                let x = center_x.saturating_sub(node.render_width(available_width) / 2);
+                node.position = Some((x, *current_y));
+                *current_y += node.render_height() + NODE_VERTICAL_SPACING;
+            }
+        }
+    }
+
+    /// Position `indices` as a vertical stack at a fixed `x`, returning the `y`
+    /// just past the last placed node.
+    fn stack_at(&mut self, indices: &[usize], x: u16, start_y: u16) -> u16 {
+        let mut y = start_y;
+        for &idx in indices {
+            if let Some(node) = self.nodes.get_mut(idx) {
+                node.position = Some((x, y));
+                y += node.render_height() + NODE_VERTICAL_SPACING;
+            }
+        }
+        y
+    }
+
+    /// Widest rendered width among `indices`, falling back to the minimum width.
+    fn max_render_width(&self, indices: &[usize], available_width: u16) -> u16 {
+        indices
+            .iter()
+            .filter_map(|&idx| self.nodes.get(idx))
+            .map(|node| node.render_width(available_width))
+            .max()
+            .unwrap_or(MIN_NODE_WIDTH)
+    }
+
+    /// Calculate a simple hierarchical layout for the graph.
+    /// Sources sit at the top, the object in the middle, inventory at the bottom.
+    /// Returns the (width, height) the layout occupies.
     pub fn calculate_layout(&mut self, available_width: u16, _available_height: u16) -> (u16, u16) {
         if self.nodes.is_empty() {
             return (0, 0);
         }
 
-        // Flexible layout with dynamic sizing
-        // UPSTREAM FIRST (sources at top), then object, then workloads/resources at bottom
-        let min_node_width = 30u16; // Minimum width per node
-        let max_node_width = available_width.saturating_sub(4).min(60); // Max width, leave margins
-        let vertical_spacing = 3u16; // Space between nodes (increased from 2)
-
-        // Group nodes by type
-        let mut object_nodes = Vec::new();
-        let mut chain_nodes = Vec::new();
-        let mut source_nodes = Vec::new();
-        let mut upstream_nodes = Vec::new();
-        let mut flux_resource_nodes = Vec::new();
-        let mut workload_nodes = Vec::new();
-        let mut workload_group_nodes = Vec::new();
-        let mut resource_group_nodes = Vec::new();
-
+        // Bucket node indices by type so each layer can be positioned in turn.
+        // Individual Workload nodes are never placed directly (they're aggregated
+        // into a WorkloadGroup by the builder), so they're intentionally skipped.
+        let mut upstream = Vec::new();
+        let mut sources = Vec::new();
+        let mut chain = Vec::new();
+        let mut object = Vec::new();
+        let mut flux = Vec::new();
+        let mut workload_groups = Vec::new();
+        let mut resource_groups = Vec::new();
         for (idx, node) in self.nodes.iter().enumerate() {
             match node.node_type {
-                NodeType::Object => object_nodes.push(idx),
-                NodeType::Chain => chain_nodes.push(idx),
-                NodeType::Source => source_nodes.push(idx),
-                NodeType::Upstream => upstream_nodes.push(idx),
-                NodeType::FluxResource => flux_resource_nodes.push(idx),
-                NodeType::Workload => workload_nodes.push(idx),
-                NodeType::WorkloadGroup => workload_group_nodes.push(idx),
-                NodeType::ResourceGroup => resource_group_nodes.push(idx),
+                NodeType::Upstream => upstream.push(idx),
+                NodeType::Source => sources.push(idx),
+                NodeType::Chain => chain.push(idx),
+                NodeType::Object => object.push(idx),
+                NodeType::FluxResource => flux.push(idx),
+                NodeType::WorkloadGroup => workload_groups.push(idx),
+                NodeType::ResourceGroup => resource_groups.push(idx),
+                NodeType::Workload => {}
             }
         }
 
-        // Calculate positions with flexible layout
-        // UPSTREAM FIRST (sources at top), then object, then workloads/resources at bottom
         let center_x = available_width / 2;
         let mut current_y = 1u16;
 
-        // Calculate node dimensions based on content
-        let calculate_node_width = |node: &GraphNode| -> u16 {
-            let name_len = node.name.len() as u16;
-            let kind_len = node.kind.len() as u16;
-            let desc_len = node
-                .description
-                .as_ref()
-                .map(|d| d.len() as u16)
-                .unwrap_or(0);
-            let max_content = name_len.max(kind_len).max(desc_len);
-            max_content.max(min_node_width).min(max_node_width)
-        };
-
-        let calculate_node_height = |node: &GraphNode| -> u16 {
-            // Calculate height: title section + content + borders
-            // For WorkloadGroup/ResourceGroup: name (1) + separator (1) + borders (2) = 4
-            // For other nodes: kind label (1) + name (1) + separator (1) + borders (2) = 5
-            let mut height = if matches!(
-                node.node_type,
-                NodeType::WorkloadGroup | NodeType::ResourceGroup
-            ) {
-                4u16 // name + separator + borders
-            } else {
-                5u16 // kind label + name + separator + borders
-            };
-
-            // Workload nodes have: type label + name + description (replica count) + resource name subtitle
-            if matches!(node.node_type, NodeType::Workload) {
-                if node.description.is_some() {
-                    height += 2; // description line + resource name subtitle
-                }
-            } else if matches!(node.node_type, NodeType::WorkloadGroup) {
-                // Workload group nodes show each workload as 4-5 lines (kind, name, status, optional namespace) + 1 blank line between
-                if let Some(ref desc) = node.description {
-                    // Count the number of workloads (separated by newlines)
-                    let workload_lines: Vec<&str> = desc.lines().collect();
-                    let workload_count = workload_lines.len();
-
-                    if workload_count > 0 {
-                        // Check if namespaces differ (if so, namespace line will be shown for each workload)
-                        let show_namespace = if workload_count > 1 {
-                            let first_namespace = workload_lines[0].split('|').nth(2).unwrap_or("");
-                            !workload_lines
-                                .iter()
-                                .all(|line| line.split('|').nth(2).unwrap_or("") == first_namespace)
-                        } else {
-                            false
-                        };
-
-                        // Each workload: kind (1) + name (1) + status (1) + namespace (0-1) = 3-4 lines
-                        // Plus 1 blank line between workloads (workload_count - 1 blank lines)
-                        let lines_per_workload = if show_namespace { 4 } else { 3 };
-                        let blank_lines = workload_count.saturating_sub(1);
-                        height += (workload_count * lines_per_workload + blank_lines) as u16;
-                    }
-                }
-            } else if matches!(node.node_type, NodeType::ResourceGroup) {
-                // Resource group nodes show each resource kind on a separate line
-                if let Some(ref desc) = node.description {
-                    // Count the number of resource items (separated by ", ")
-                    let item_count = desc.matches(", ").count() + 1;
-                    height += item_count as u16;
-                }
-            } else {
-                if node.description.is_some() {
-                    height += 1; // description line
-                }
-                if node.ready.is_some() {
-                    height += 1; // status line
-                }
-            }
-            height
-        };
-
-        // Position upstream nodes at VERY TOP (external sources like GitHub URLs)
-        for &idx in &upstream_nodes {
-            if let Some(node) = self.nodes.get_mut(idx) {
-                let node_width = calculate_node_width(node);
-                let node_height = calculate_node_height(node);
-                node.position = Some((center_x.saturating_sub(node_width / 2), current_y));
-                current_y += node_height + vertical_spacing;
-            }
+        // Centered single-column layers, top to bottom.
+        for layer in [&upstream, &sources, &chain, &object, &flux] {
+            self.stack_centered(layer, available_width, center_x, &mut current_y);
         }
 
-        // Position source nodes (Flux source resources)
-        for &idx in &source_nodes {
-            if let Some(node) = self.nodes.get_mut(idx) {
-                let node_width = calculate_node_width(node);
-                let node_height = calculate_node_height(node);
-                node.position = Some((center_x.saturating_sub(node_width / 2), current_y));
-                current_y += node_height + vertical_spacing;
-            }
-        }
-
-        // Position chain nodes in middle (intermediate resources like HelmChart)
-        for &idx in &chain_nodes {
-            if let Some(node) = self.nodes.get_mut(idx) {
-                let node_width = calculate_node_width(node);
-                let node_height = calculate_node_height(node);
-                node.position = Some((center_x.saturating_sub(node_width / 2), current_y));
-                current_y += node_height + vertical_spacing;
-            }
-        }
-
-        // Position object node (the Kustomization/HelmRelease being viewed)
-        for &idx in &object_nodes {
-            if let Some(node) = self.nodes.get_mut(idx) {
-                let node_width = calculate_node_width(node);
-                let node_height = calculate_node_height(node);
-                node.position = Some((center_x.saturating_sub(node_width / 2), current_y));
-                current_y += node_height + vertical_spacing;
-            }
-        }
-
-        // Position Flux resources managed by this resource (individual items)
-        for &idx in &flux_resource_nodes {
-            if let Some(node) = self.nodes.get_mut(idx) {
-                let node_width = calculate_node_width(node);
-                let node_height = calculate_node_height(node);
-                node.position = Some((center_x.saturating_sub(node_width / 2), current_y));
-                current_y += node_height + vertical_spacing;
-            }
-        }
-
-        // Position inventory nodes at BOTTOM (side by side if multiple categories)
+        // Inventory groups at the bottom.
         let inventory_y = current_y;
-        let has_workload_groups = !workload_group_nodes.is_empty();
-        let has_resource_groups = !resource_group_nodes.is_empty();
+        match (!workload_groups.is_empty(), !resource_groups.is_empty()) {
+            (true, true) => {
+                // Side by side, centered as a pair with a small gap so the fan-out
+                // from the parent stays tight rather than spanning the whole width.
+                let left_w = self.max_render_width(&workload_groups, available_width);
+                let right_w = self.max_render_width(&resource_groups, available_width);
+                let total = left_w + INVENTORY_GROUP_GAP + right_w;
+                let left_x = center_x.saturating_sub(total / 2);
+                let right_x = left_x + left_w + INVENTORY_GROUP_GAP;
 
-        if has_workload_groups && has_resource_groups {
-            // Both workload groups and resource groups exist - place side by side
-            let left_x = center_x.saturating_sub(max_node_width + 5);
-            let right_x = center_x + 5;
-
-            // Workload groups on left
-            let mut workloads_y = inventory_y;
-            for &idx in &workload_group_nodes {
-                if let Some(node) = self.nodes.get_mut(idx) {
-                    let node_height = calculate_node_height(node);
-                    node.position = Some((left_x, workloads_y));
-                    workloads_y += node_height + vertical_spacing;
-                }
+                let left_end = self.stack_at(&workload_groups, left_x, inventory_y);
+                let right_end = self.stack_at(&resource_groups, right_x, inventory_y);
+                current_y = left_end.max(right_end);
             }
-
-            // Resource groups on right
-            let mut resources_y = inventory_y;
-            for &idx in &resource_group_nodes {
-                if let Some(node) = self.nodes.get_mut(idx) {
-                    let node_height = calculate_node_height(node);
-                    node.position = Some((right_x, resources_y));
-                    resources_y += node_height + vertical_spacing;
-                }
+            (true, false) => {
+                self.stack_centered(&workload_groups, available_width, center_x, &mut current_y)
             }
-
-            current_y = workloads_y.max(resources_y);
-        } else if has_workload_groups {
-            // Only workload groups - center them
-            for &idx in &workload_group_nodes {
-                if let Some(node) = self.nodes.get_mut(idx) {
-                    let node_width = calculate_node_width(node);
-                    let node_height = calculate_node_height(node);
-                    node.position = Some((center_x.saturating_sub(node_width / 2), current_y));
-                    current_y += node_height + vertical_spacing;
-                }
+            (false, true) => {
+                self.stack_centered(&resource_groups, available_width, center_x, &mut current_y)
             }
-        } else if has_resource_groups {
-            // Only resource groups - center them
-            for &idx in &resource_group_nodes {
-                if let Some(node) = self.nodes.get_mut(idx) {
-                    let node_width = calculate_node_width(node);
-                    let node_height = calculate_node_height(node);
-                    node.position = Some((center_x.saturating_sub(node_width / 2), current_y));
-                    current_y += node_height + vertical_spacing;
-                }
-            }
+            (false, false) => {}
         }
 
         (available_width, current_y)
@@ -329,5 +338,119 @@ impl ResourceGraph {
 impl Default for ResourceGraph {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node(id: &str, node_type: NodeType) -> GraphNode {
+        GraphNode {
+            id: id.to_string(),
+            kind: "Test".to_string(),
+            name: id.to_string(),
+            namespace: "default".to_string(),
+            node_type,
+            ready: None,
+            position: None,
+            description: None,
+        }
+    }
+
+    #[test]
+    fn focus_order_sorts_top_to_bottom_by_layer() {
+        // Insertion order deliberately scrambles the visual layering.
+        let mut graph = ResourceGraph::new();
+        graph.add_node(node("object", NodeType::Object)); // idx 0, layer 3
+        graph.add_node(node("source", NodeType::Source)); // idx 1, layer 1
+        graph.add_node(node("wg", NodeType::WorkloadGroup)); // idx 2, layer 5
+        graph.add_node(node("upstream", NodeType::Upstream)); // idx 3, layer 0
+
+        // Expected visual order: upstream, source, object, workload group.
+        assert_eq!(graph.focus_order(), vec![3, 1, 0, 2]);
+    }
+
+    #[test]
+    fn focus_order_preserves_insertion_within_a_layer() {
+        let mut graph = ResourceGraph::new();
+        graph.add_node(node("flux-a", NodeType::FluxResource));
+        graph.add_node(node("flux-b", NodeType::FluxResource));
+        graph.add_node(node("flux-c", NodeType::FluxResource));
+
+        assert_eq!(graph.focus_order(), vec![0, 1, 2]);
+    }
+
+    fn node_with(node_type: NodeType, description: Option<&str>, ready: Option<bool>) -> GraphNode {
+        GraphNode {
+            id: "id".to_string(),
+            kind: "GitRepository".to_string(),
+            name: "name".to_string(),
+            namespace: "default".to_string(),
+            node_type,
+            ready,
+            position: None,
+            description: description.map(|d| d.to_string()),
+        }
+    }
+
+    #[test]
+    fn render_height_matches_rendered_rows() {
+        // Plain node: 5 rows of chrome only.
+        assert_eq!(node_with(NodeType::Object, None, None).render_height(), 5);
+        // Plain node with a description and a status line: 5 + 1 + 1.
+        assert_eq!(
+            node_with(NodeType::Source, Some("https://x"), Some(true)).render_height(),
+            7
+        );
+        // Resource group: 4 chrome + one row per kind ("A: 1, B: 2, C: 3" => 3).
+        assert_eq!(
+            node_with(NodeType::ResourceGroup, Some("A: 1, B: 2, C: 3"), None).render_height(),
+            7
+        );
+        // Workload group, single workload (no namespace row): 4 + 3.
+        assert_eq!(
+            node_with(
+                NodeType::WorkloadGroup,
+                Some("Deployment|a|ns1|●|1/1"),
+                None
+            )
+            .render_height(),
+            7
+        );
+        // Workload group, two workloads in differing namespaces: 4 + (2*4 + 1).
+        assert_eq!(
+            node_with(
+                NodeType::WorkloadGroup,
+                Some("Deployment|a|ns1|●|1/1\nDeployment|b|ns2|●|2/2"),
+                None,
+            )
+            .render_height(),
+            13
+        );
+    }
+
+    #[test]
+    fn render_width_clamps_to_bounds_and_available() {
+        let short = node_with(NodeType::Object, None, None); // content < MIN
+        assert_eq!(short.render_width(100), MIN_NODE_WIDTH);
+
+        // Long description pushes content past MAX, so it clamps to MAX.
+        let long = node_with(NodeType::Object, Some(&"x".repeat(120)), None);
+        assert_eq!(long.render_width(100), MAX_NODE_WIDTH);
+
+        // A narrow viewport wins over the content-based width.
+        assert_eq!(long.render_width(20), 20 - NODE_HORIZONTAL_CHROME);
+    }
+
+    #[test]
+    fn object_node_index_finds_the_object() {
+        let mut graph = ResourceGraph::new();
+        graph.add_node(node("source", NodeType::Source));
+        graph.add_node(node("object", NodeType::Object));
+        assert_eq!(graph.object_node_index(), Some(1));
+
+        let empty = ResourceGraph::new();
+        assert_eq!(empty.object_node_index(), None);
     }
 }

--- a/src/tui/app/async_ops.rs
+++ b/src/tui/app/async_ops.rs
@@ -238,6 +238,9 @@ impl App {
 
     /// Set graph result
     pub fn set_graph_result(&mut self, result: crate::trace::ResourceGraph) {
+        // Start keyboard focus on the resource being viewed (the object node) so
+        // the graph is immediately navigable with j/k and Enter.
+        self.view_state.graph_focus_index = result.object_node_index();
         self.async_state.graph_result = Some(result);
     }
 

--- a/src/tui/app/events.rs
+++ b/src/tui/app/events.rs
@@ -5,61 +5,61 @@
 
 use super::core::App;
 use super::state::{HealthFilter, PendingOperation, View};
+use crate::tui::commands;
 use crate::watcher::ResourceKey;
 use crossterm::event::KeyEvent;
+
+/// A `:` command handler dispatched from [`App::execute_command`]. Receives the
+/// app and the original (case-preserving) command string.
+type CommandHandler = fn(&mut App, &str);
+
+/// Data-driven dispatch for the uniform `(predicate over the lowercased command,
+/// handler)` `:` commands. Checked in order; the first matching predicate wins.
+/// Special commands (help/quit/readonly, the connection gate) and the
+/// resource-type fallback are handled directly in [`App::execute_command`].
+const COMMAND_TABLE: &[(fn(&str) -> bool, CommandHandler)] = &[
+    (commands::is_skin_command, App::cmd_set_skin),
+    (commands::is_trace_command, App::cmd_trace),
+    (commands::is_context_command, App::cmd_switch_context),
+    (commands::is_namespace_command, App::cmd_switch_namespace),
+    (commands::is_healthy_command, App::cmd_filter_healthy),
+    (commands::is_unhealthy_command, App::cmd_filter_unhealthy),
+    (commands::is_favorites_command, App::cmd_show_favorites),
+    (commands::is_all_command, App::cmd_show_all),
+];
 
 impl App {
     /// Scroll the active view down by `amount` lines, or advance the list
     /// selection when a list view is active. Shared by j/Down, PageDown and
     /// Ctrl+F so all scroll keys behave identically in every view.
     fn scroll_down(&mut self, amount: usize) {
-        match self.view_state.current_view {
-            View::ResourceYAML => self.view_state.yaml_scroll_offset += amount,
-            View::ResourceDescribe => self.view_state.describe_scroll_offset += amount,
-            View::ResourceTrace => self.view_state.trace_scroll_offset += amount,
-            View::ResourceHistory => self.view_state.history_scroll_offset += amount,
-            View::ResourceGraph => self.view_state.graph_scroll_offset += amount,
-            _ => {
-                let resources = self.get_filtered_resources();
-                let max_index = resources.len().saturating_sub(1);
-                self.view_state.selected_index =
-                    (self.view_state.selected_index + amount).min(max_index);
-            }
+        let view = self.view_state.current_view;
+        // In the graph, j/Down/PageDown move keyboard focus between nodes instead
+        // of free-scrolling; the renderer scrolls to keep the focused node on screen.
+        if view == View::ResourceGraph {
+            self.move_graph_focus(true);
+        } else if let Some(offset) = view.scroll_offset_mut(&mut self.view_state) {
+            *offset += amount;
+        } else {
+            let resources = self.get_filtered_resources();
+            let max_index = resources.len().saturating_sub(1);
+            self.view_state.selected_index =
+                (self.view_state.selected_index + amount).min(max_index);
         }
     }
 
     /// Scroll the active view up by `amount` lines, or move the list selection
     /// up when a list view is active (keeping the selection visible).
     fn scroll_up(&mut self, amount: usize) {
-        match self.view_state.current_view {
-            View::ResourceYAML => {
-                self.view_state.yaml_scroll_offset =
-                    self.view_state.yaml_scroll_offset.saturating_sub(amount);
-            }
-            View::ResourceDescribe => {
-                self.view_state.describe_scroll_offset = self
-                    .view_state
-                    .describe_scroll_offset
-                    .saturating_sub(amount);
-            }
-            View::ResourceTrace => {
-                self.view_state.trace_scroll_offset =
-                    self.view_state.trace_scroll_offset.saturating_sub(amount);
-            }
-            View::ResourceHistory => {
-                self.view_state.history_scroll_offset =
-                    self.view_state.history_scroll_offset.saturating_sub(amount);
-            }
-            View::ResourceGraph => {
-                self.view_state.graph_scroll_offset =
-                    self.view_state.graph_scroll_offset.saturating_sub(amount);
-            }
-            _ => {
-                self.view_state.selected_index =
-                    self.view_state.selected_index.saturating_sub(amount);
-                if self.view_state.selected_index < self.view_state.scroll_offset {
-                    self.view_state.scroll_offset = self.view_state.selected_index;
-                }
+        let view = self.view_state.current_view;
+        if view == View::ResourceGraph {
+            self.move_graph_focus(false);
+        } else if let Some(offset) = view.scroll_offset_mut(&mut self.view_state) {
+            *offset = offset.saturating_sub(amount);
+        } else {
+            self.view_state.selected_index = self.view_state.selected_index.saturating_sub(amount);
+            if self.view_state.selected_index < self.view_state.scroll_offset {
+                self.view_state.scroll_offset = self.view_state.selected_index;
             }
         }
     }
@@ -412,9 +412,12 @@ impl App {
                 }
             }
             crossterm::event::KeyCode::Enter
-                if (self.view_state.current_view == View::ResourceList
-                    || self.view_state.current_view == View::ResourceFavorites) =>
+                if self.view_state.current_view == View::ResourceGraph =>
             {
+                // Drill into the focused graph node's resource.
+                self.navigate_to_focused_graph_node();
+            }
+            crossterm::event::KeyCode::Enter if self.view_state.current_view.is_list_view() => {
                 // Save current view as previous list view before navigating
                 self.view_state.previous_list_view = self.view_state.current_view;
                 let resources = self.get_filtered_resources();
@@ -425,14 +428,13 @@ impl App {
                         &resource.resource_type,
                     );
                     self.selection_state.selected_resource_key = Some(key);
+                    // Opened from the list, so Back returns to the list.
+                    self.view_state.detail_back_view = None;
                     self.view_state.current_view = View::ResourceDetail;
                 }
             }
             // Toggle favorite - works from list view
-            crossterm::event::KeyCode::Char('f')
-                if (self.view_state.current_view == View::ResourceList
-                    || self.view_state.current_view == View::ResourceFavorites) =>
-            {
+            crossterm::event::KeyCode::Char('f') if self.view_state.current_view.is_list_view() => {
                 let resources = self.get_filtered_resources();
                 if let Some(resource) = resources.get(self.view_state.selected_index) {
                     let key = crate::watcher::resource_key(
@@ -522,9 +524,7 @@ impl App {
                     }
 
                     // Save current view as previous list view before navigating
-                    if self.view_state.current_view == View::ResourceList
-                        || self.view_state.current_view == View::ResourceFavorites
-                    {
+                    if self.view_state.current_view.is_list_view() {
                         self.view_state.previous_list_view = self.view_state.current_view;
                     }
 
@@ -543,6 +543,7 @@ impl App {
                     });
                     self.async_state.graph_result = None; // Clear previous graph
                     self.view_state.graph_scroll_offset = 0; // Reset scroll
+                    self.view_state.graph_focus_index = None; // Reset focus (set when graph loads)
                     self.view_state.current_view = View::ResourceGraph;
                 } else {
                     self.set_status_message(("No resource selected".to_string(), true));
@@ -550,17 +551,16 @@ impl App {
             }
             crossterm::event::KeyCode::Backspace => {
                 // Backspace goes back (same as Escape for detail view)
-                if self.view_state.current_view == View::ResourceDetail
-                    || self.view_state.current_view == View::ResourceDescribe
-                    || self.view_state.current_view == View::ResourceYAML
-                    || self.view_state.current_view == View::ResourceTrace
-                    || self.view_state.current_view == View::ResourceHistory
-                    || self.view_state.current_view == View::ResourceGraph
-                {
-                    // Return to previous list view (favorites if we came from there, otherwise list)
-                    self.view_state.current_view = self.view_state.previous_list_view;
-                    self.selection_state.selected_resource_key = None;
-                    self.view_state.text_search.clear();
+                if self.view_state.current_view.is_nested_view() {
+                    // Mirror Esc: return to the graph if we came from there,
+                    // otherwise to the previous list view.
+                    if let Some(back) = self.detail_graph_back() {
+                        self.view_state.current_view = back;
+                    } else {
+                        self.view_state.current_view = self.view_state.previous_list_view;
+                        self.selection_state.selected_resource_key = None;
+                        self.view_state.text_search.clear();
+                    }
                 } else if self.view_state.current_view == View::ResourceFavorites {
                     self.view_state.current_view = View::ResourceList;
                     self.selection_state.selected_resource_key = None;
@@ -620,10 +620,7 @@ impl App {
 
     /// Whether the current view supports text search (`/`)
     fn is_text_search_view(&self) -> bool {
-        matches!(
-            self.view_state.current_view,
-            View::ResourceYAML | View::ResourceDescribe | View::ResourceTrace
-        )
+        self.view_state.current_view.is_text_search_view()
     }
 
     /// Handle a key press while typing a text-view search query
@@ -772,6 +769,98 @@ impl App {
     /// Shared implementation for `q` and `Esc`, matching k9s behaviour where
     /// neither key exits the application directly. The help overlay is treated as
     /// a navigable layer and is dismissed first before any view transition occurs.
+    /// Move keyboard focus between graph nodes in visual (top-to-bottom) order.
+    /// Clamps at the ends rather than wrapping so the direction stays intuitive.
+    /// Auto-scrolling to keep the focused node visible is handled by the renderer.
+    fn move_graph_focus(&mut self, forward: bool) {
+        let Some(graph) = self.async_state.graph_result.as_ref() else {
+            return;
+        };
+        let order = graph.focus_order();
+        if order.is_empty() {
+            return;
+        }
+
+        // Where the current focus sits within the visual order (start by default).
+        let current_pos = self
+            .view_state
+            .graph_focus_index
+            .and_then(|idx| order.iter().position(|&i| i == idx));
+
+        let next_pos = match current_pos {
+            Some(pos) if forward => (pos + 1).min(order.len() - 1),
+            Some(pos) => pos.saturating_sub(1),
+            None => 0,
+        };
+        self.view_state.graph_focus_index = Some(order[next_pos]);
+    }
+
+    /// Open the detail view for the focused graph node when it maps to a watched
+    /// resource. Aggregate nodes (workload/resource groups) and external upstream
+    /// URLs are not directly navigable and just show a hint instead.
+    fn navigate_to_focused_graph_node(&mut self) {
+        use crate::trace::NodeType;
+
+        // Pull the owned identity out first so the immutable borrow of the graph
+        // ends before we mutate view/selection state below.
+        let Some((node_type, kind, namespace, name)) = self
+            .async_state
+            .graph_result
+            .as_ref()
+            .and_then(|graph| {
+                self.view_state
+                    .graph_focus_index
+                    .and_then(|idx| graph.nodes.get(idx))
+            })
+            .map(|n| {
+                (
+                    n.node_type,
+                    n.kind.clone(),
+                    n.namespace.clone(),
+                    n.name.clone(),
+                )
+            })
+        else {
+            return;
+        };
+
+        if matches!(
+            node_type,
+            NodeType::WorkloadGroup | NodeType::ResourceGroup | NodeType::Upstream
+        ) {
+            self.set_status_message((
+                "Aggregate node — select an individual Flux resource to open it".to_string(),
+                false,
+            ));
+            return;
+        }
+
+        let key = crate::watcher::resource_key(&namespace, &name, &kind);
+        if self.state.get(&key).is_some() {
+            self.selection_state.selected_resource_key = Some(key);
+            // Remember to return to the graph (not the list) when the user backs
+            // out of the detail view.
+            self.view_state.detail_back_view = Some(View::ResourceGraph);
+            self.view_state.current_view = View::ResourceDetail;
+        } else {
+            self.set_status_message((
+                format!("{} {} is not in the current view", kind, name),
+                false,
+            ));
+        }
+    }
+
+    /// If the detail view was entered by drilling into a graph node, consume and
+    /// return the stored back target (the graph). Returns `None` for any other
+    /// view or entry path, leaving normal back-to-list behaviour in place.
+    fn detail_graph_back(&mut self) -> Option<View> {
+        if self.view_state.current_view == View::ResourceDetail {
+            self.view_state.detail_back_view.take()
+        } else {
+            None
+        }
+    }
+
     fn navigate_back_or_confirm_quit(&mut self) -> Option<bool> {
         if self.ui_state.show_help {
             self.ui_state.show_help = false;
@@ -790,11 +879,16 @@ impl App {
             | View::ResourceTrace
             | View::ResourceHistory
             | View::ResourceGraph => {
-                // Go back to the previous list view (favourites if we came from
-                // there, otherwise the main resource list).
-                self.view_state.current_view = self.view_state.previous_list_view;
-                self.selection_state.selected_resource_key = None;
-                self.view_state.text_search.clear();
+                // If we drilled into this detail view from the graph, return to
+                // the graph; otherwise go back to the previous list view
+                // (favourites if we came from there, else the main resource list).
+                if let Some(back) = self.detail_graph_back() {
+                    self.view_state.current_view = back;
+                } else {
+                    self.view_state.current_view = self.view_state.previous_list_view;
+                    self.selection_state.selected_resource_key = None;
+                    self.view_state.text_search.clear();
+                }
                 None
             }
             View::ResourceFavorites => {
@@ -1033,43 +1127,36 @@ impl App {
         }
     }
 
+    /// Execute the command currently in the command buffer.
+    ///
+    /// A few commands are special and handled up front: help/quit toggle global
+    /// state, readonly runs before the connection gate, and the gate blocks most
+    /// commands while disconnected. Everything else is dispatched through
+    /// [`COMMAND_TABLE`] (a data-driven `(predicate, handler)` list); unmatched
+    /// input falls through to resource-type selection or an "unknown command"
+    /// message. Returns `Some(true)` only to quit.
     fn execute_command(&mut self) -> Option<bool> {
-        let cmd = self.ui_state.command_buffer.trim();
+        // Own the command string so the per-command handlers can take `&mut self`
+        // without conflicting with a borrow of the command buffer.
+        let cmd = self.ui_state.command_buffer.trim().to_string();
         let cmd_lower = cmd.to_lowercase();
 
-        // Handle help command
-        if crate::tui::commands::is_help_command(&cmd_lower) {
+        if commands::is_help_command(&cmd_lower) {
             self.ui_state.show_help = !self.ui_state.show_help;
             return None;
         }
-
-        // Handle quit commands
-        if crate::tui::commands::is_quit_command(&cmd_lower) {
-            return Some(true); // Quit
+        if commands::is_quit_command(&cmd_lower) {
+            return Some(true);
         }
-
-        // Handle readonly toggle command
-        if crate::tui::commands::is_readonly_command(&cmd_lower) {
-            self.config.read_only = !self.config.read_only;
-            let status = if self.config.read_only {
-                "enabled"
-            } else {
-                "disabled"
-            };
-
-            // Reload skin based on readonly mode
-            // Clone context name to avoid borrow checker issues
-            let context_name = self.context.clone();
-            self.reload_skin_for_readonly_mode(Some(&context_name));
-
-            self.set_status_message((format!("Readonly mode {}", status), false));
+        if commands::is_readonly_command(&cmd_lower) {
+            self.cmd_toggle_readonly();
             return None;
         }
 
-        // If we have a connection error, block all commands except context and skin commands.
+        // While disconnected, only context/skin commands are allowed through.
         if self.has_connection_error()
-            && !crate::tui::commands::is_context_command(&cmd_lower)
-            && !crate::tui::commands::is_skin_command(&cmd_lower)
+            && !commands::is_context_command(&cmd_lower)
+            && !commands::is_skin_command(&cmd_lower)
         {
             self.set_status_message((
                 "Commands are disabled when disconnected (except :ctx, :skin, :q)".to_string(),
@@ -1078,267 +1165,18 @@ impl App {
             return None;
         }
 
-        // Handle skin/theme change command
-        if crate::tui::commands::is_skin_command(&cmd_lower) {
-            let theme_name = crate::tui::commands::extract_command_arg(cmd, "skin");
-            match theme_name {
-                Some(name) => {
-                    // Argument provided - change theme directly
-                    match self.set_theme(&name) {
-                        Ok(_) => {
-                            let msg = format!("Theme changed to: {}", name);
-                            self.set_status_message((msg, false));
-                        }
-                        Err(e) => {
-                            let msg = format!(
-                                "Failed to load theme '{}': {}. Use `default` to return to default theme",
-                                name, e
-                            );
-                            self.set_status_message((msg, true));
-                        }
-                    }
-                }
-                None => {
-                    // No argument - show submenu or list themes
-                    let current_theme = self.config.resolve_skin_name(Some(&self.context));
-
-                    if let Some(submenu) = crate::tui::commands::get_command_submenu(
-                        cmd,
-                        &self.context,
-                        &current_theme,
-                    ) {
-                        // Store original theme for skin submenu preview
-                        if submenu.command == "skin" {
-                            self.view_state.preview_original_theme = Some(current_theme.clone());
-                            // Preview the first theme immediately
-                            if let Some(first_theme) = submenu.selected_value() {
-                                let _ = self.preview_theme(&first_theme);
-                            }
-                        }
-                        // Open submenu for selection
-                        self.view_state.submenu_state = Some(submenu);
-                    } else {
-                        // Fallback: List available themes
-                        let themes = crate::config::theme_loader::ThemeLoader::list_themes();
-                        let msg = format!(
-                            "Available themes: {}. Current: {}. Usage: :skin <theme-name>",
-                            themes.join(", "),
-                            current_theme
-                        );
-                        self.set_status_message((msg, false));
-                    }
-                }
+        // Data-driven dispatch: first predicate to match owns the command.
+        for (matches, handle) in COMMAND_TABLE {
+            if matches(&cmd_lower) {
+                handle(self, &cmd);
+                return None;
             }
-            return None;
         }
 
-        // Handle trace command - trace ownership chain
-        if crate::tui::commands::is_trace_command(&cmd_lower) {
-            let trace_arg = crate::tui::commands::extract_command_arg(cmd, "trace");
-            if trace_arg.is_none() {
-                // If no args, trace currently selected resource
-                if let Some(key) = &self.selection_state.selected_resource_key {
-                    if let Some(rk) = ResourceKey::parse(key) {
-                        self.async_state.trace_pending = Some(rk);
-                        self.async_state.trace_result = None;
-                    } else {
-                        tracing::warn!("Failed to parse resource key for trace command: {}", key);
-                        self.ui_state.status_message =
-                            Some(("Invalid resource key format".to_string(), true));
-                    }
-                } else {
-                    self.set_status_message(("No resource selected".to_string(), true));
-                }
-            } else if let Some(trace_arg) = trace_arg {
-                // Parse resource type/name format (e.g., "kustomization/cabot-book" or "Kustomization/cabot-book")
-                let resource_parts: Vec<&str> = trace_arg.split('/').collect();
-                if resource_parts.len() == 2 {
-                    let resource_type = resource_parts[0];
-                    let name = resource_parts[1];
-                    use crate::models::FluxResourceKind;
-                    // Normalize resource type to proper case
-                    let resource_type_normalized =
-                        match FluxResourceKind::from_str_case_insensitive(resource_type) {
-                            Some(kind) => kind.as_str(),
-                            None => {
-                                // Handle standard Kubernetes resources
-                                match resource_type.to_lowercase().as_str() {
-                                    "deployment" | "deploy" => "Deployment",
-                                    "service" => "Service",
-                                    "pod" => "Pod",
-                                    _ => resource_type,
-                                }
-                            }
-                        };
-                    let namespace = self
-                        .namespace()
-                        .clone()
-                        .unwrap_or_else(|| "default".to_string());
-                    self.async_state.trace_pending = Some(ResourceKey::new(
-                        resource_type_normalized.to_string(),
-                        namespace,
-                        name.to_string(),
-                    ));
-                    self.async_state.trace_result = None;
-                } else {
-                    self.set_status_message((
-                        "Usage: :trace <resource-type>/<name> or :trace (for selected)".to_string(),
-                        true,
-                    ));
-                }
-            }
-            return None;
-        }
-
-        // Handle context switching - reconnect to different cluster
-        if crate::tui::commands::is_context_command(&cmd_lower) {
-            // Try "context" first, then "ctx" as fallback
-            let context_name = crate::tui::commands::extract_command_arg(cmd, "context")
-                .or_else(|| crate::tui::commands::extract_command_arg(cmd, "ctx"));
-
-            match context_name {
-                Some(ctx) => {
-                    // Mark context switch as pending - will be handled in main loop
-                    self.pending_context_switch = Some(ctx.to_string());
-                    self.set_status_message((format!("Switching to context '{}'...", ctx), false));
-                }
-                None => {
-                    // Get current theme name (considering readonly mode and env vars)
-                    let current_theme = self.config.resolve_skin_name(Some(&self.context));
-
-                    // Check if command supports submenu
-                    if let Some(submenu) = crate::tui::commands::get_command_submenu(
-                        cmd,
-                        &self.context,
-                        &current_theme,
-                    ) {
-                        // Store original theme for skin submenu preview
-                        if submenu.command == "skin" {
-                            self.view_state.preview_original_theme = Some(current_theme.clone());
-                            // Preview the first theme immediately
-                            if let Some(first_theme) = submenu.selected_value() {
-                                let _ = self.preview_theme(&first_theme);
-                            }
-                        }
-                        // Open submenu for selection
-                        self.view_state.submenu_state = Some(submenu);
-                    } else {
-                        // Fallback: List available contexts in status message
-                        match crate::kube::list_contexts() {
-                            Ok(contexts) => {
-                                let current = self.context.clone();
-                                let msg = format!(
-                                    "Available contexts: {}. Current: {}. Usage: :ctx <context-name>",
-                                    contexts.join(", "),
-                                    current
-                                );
-                                self.set_status_message((msg, false));
-                            }
-                            Err(e) => {
-                                self.set_status_message((
-                                    format!("Failed to list contexts: {}", e),
-                                    true,
-                                ));
-                            }
-                        }
-                    }
-                }
-            }
-            return None;
-        }
-
-        // Handle namespace switching - restart watchers with new namespace
-        if crate::tui::commands::is_namespace_command(&cmd_lower) {
-            // Try "namespace" first, then "ns" as fallback
-            let ns = crate::tui::commands::extract_command_arg(cmd, "namespace")
-                .or_else(|| crate::tui::commands::extract_command_arg(cmd, "ns"));
-            let new_namespace = match ns.as_deref() {
-                Some("all") | Some("-A") => None,
-                Some(ns_name) => Some(ns_name.to_string()),
-                None => {
-                    // Show current namespace - do nothing
-                    return None;
-                }
-            };
-
-            // Update namespace and restart watchers if changed
-            if self.namespace != new_namespace {
-                self.namespace = new_namespace.clone();
-
-                // Clear state when switching namespaces (will repopulate from new watchers)
-                self.state().clear();
-                self.resource_objects.clear();
-                self.controller_pods.clear();
-                // Restarted watchers start clean; stale degraded state
-                // from the old set would otherwise never clear.
-                self.degraded_watchers.clear();
-
-                // Restart watchers with new namespace (more efficient than watching all)
-                if let Some(ref mut watcher) = self.watcher {
-                    if let Err(e) = watcher.set_namespace(new_namespace) {
-                        tracing::warn!("Failed to switch namespace: {}", e);
-                        self.set_status_message((
-                            format!("Failed to switch namespace: {}", e),
-                            true,
-                        ));
-                    }
-                }
-            }
-
-            self.view_state.selected_index = 0;
-            self.view_state.scroll_offset = 0;
-            return None;
-        }
-
-        // Handle health filter commands
-        if crate::tui::commands::is_healthy_command(&cmd_lower) {
-            self.view_state.health_filter = HealthFilter::Healthy;
-            self.view_state.selected_index = 0;
-            self.view_state.scroll_offset = 0;
-            self.set_status_message(("Showing healthy resources only".to_string(), false));
-            return None;
-        }
-
-        if crate::tui::commands::is_unhealthy_command(&cmd_lower) {
-            self.view_state.health_filter = HealthFilter::Unhealthy;
-            self.view_state.selected_index = 0;
-            self.view_state.scroll_offset = 0;
-            self.set_status_message(("Showing unhealthy resources only".to_string(), false));
-            return None;
-        }
-
-        // Handle favorites command
-        if crate::tui::commands::is_favorites_command(&cmd_lower) {
-            self.view_state.current_view = View::ResourceFavorites;
-            self.view_state.selected_index = 0;
-            self.view_state.scroll_offset = 0;
-            return None;
-        }
-
-        // Use registry for resource type command mapping
-        if crate::tui::commands::is_all_command(&cmd_lower) {
-            // Clear favorites view if active
-            if self.view_state.current_view == View::ResourceFavorites {
-                self.view_state.current_view = View::ResourceList;
-            }
-            if self.view_state.selected_resource_type.is_some() {
-                self.view_state.selected_resource_type = None;
-                self.invalidate_layout_cache(); // Resource type filter affects header display
-            }
-            // Clear health filter when showing all
-            if self.view_state.health_filter != HealthFilter::All {
-                self.view_state.health_filter = HealthFilter::All;
-                self.set_status_message(("Showing all resources".to_string(), false));
-            }
-            self.view_state.selected_index = 0;
-            self.view_state.scroll_offset = 0;
-            return None;
-        }
-
+        // Fallback: a resource-type command (e.g. `:ks`, `:hr`), else unknown.
         if let Some(display_name) = crate::watcher::get_display_name_for_command(&cmd_lower) {
             self.view_state.selected_resource_type = Some(display_name.to_string());
-            self.view_state.selected_index = 0;
-            self.view_state.scroll_offset = 0;
+            self.reset_list_position();
             self.invalidate_layout_cache(); // Resource type filter affects header display
         } else if !cmd.is_empty() {
             self.set_status_message((
@@ -1351,6 +1189,232 @@ impl App {
         }
 
         None
+    }
+
+    /// Reset the list selection and scroll to the top. Shared by the commands
+    /// that change what the list shows (namespace, filters, resource type).
+    fn reset_list_position(&mut self) {
+        self.view_state.selected_index = 0;
+        self.view_state.scroll_offset = 0;
+    }
+
+    /// Toggle read-only mode and reload the matching skin.
+    fn cmd_toggle_readonly(&mut self) {
+        self.config.read_only = !self.config.read_only;
+        let status = if self.config.read_only {
+            "enabled"
+        } else {
+            "disabled"
+        };
+        // Clone context name to avoid borrowing self across the reload.
+        let context_name = self.context.clone();
+        self.reload_skin_for_readonly_mode(Some(&context_name));
+        self.set_status_message((format!("Readonly mode {}", status), false));
+    }
+
+    /// Open the interactive submenu for `cmd` if it has one (contexts, skins, …),
+    /// previewing the first skin entry. Returns whether a submenu was opened, so
+    /// callers can fall back to a status-message listing when it wasn't.
+    fn try_open_command_submenu(&mut self, cmd: &str) -> bool {
+        let current_theme = self.config.resolve_skin_name(Some(&self.context));
+        let Some(submenu) =
+            crate::tui::commands::get_command_submenu(cmd, &self.context, &current_theme)
+        else {
+            return false;
+        };
+        // Skin submenus preview as the user scrolls; remember the original to
+        // restore on cancel, and preview the first entry immediately.
+        if submenu.command == "skin" {
+            self.view_state.preview_original_theme = Some(current_theme.clone());
+            if let Some(first_theme) = submenu.selected_value() {
+                let _ = self.preview_theme(&first_theme);
+            }
+        }
+        self.view_state.submenu_state = Some(submenu);
+        true
+    }
+
+    /// `:skin [name]` — change the theme, or open the skin submenu / list themes.
+    fn cmd_set_skin(&mut self, cmd: &str) {
+        match crate::tui::commands::extract_command_arg(cmd, "skin") {
+            Some(name) => match self.set_theme(&name) {
+                Ok(_) => self.set_status_message((format!("Theme changed to: {}", name), false)),
+                Err(e) => self.set_status_message((
+                    format!(
+                        "Failed to load theme '{}': {}. Use `default` to return to default theme",
+                        name, e
+                    ),
+                    true,
+                )),
+            },
+            None if !self.try_open_command_submenu(cmd) => {
+                let themes = crate::config::theme_loader::ThemeLoader::list_themes();
+                let current = self.config.resolve_skin_name(Some(&self.context));
+                self.set_status_message((
+                    format!(
+                        "Available themes: {}. Current: {}. Usage: :skin <theme-name>",
+                        themes.join(", "),
+                        current
+                    ),
+                    false,
+                ));
+            }
+            None => {}
+        }
+    }
+
+    /// `:trace [type/name]` — trace the ownership chain of the given (or selected)
+    /// resource.
+    fn cmd_trace(&mut self, cmd: &str) {
+        let Some(trace_arg) = crate::tui::commands::extract_command_arg(cmd, "trace") else {
+            // No argument: trace the currently selected resource.
+            if let Some(key) = &self.selection_state.selected_resource_key {
+                if let Some(rk) = ResourceKey::parse(key) {
+                    self.async_state.trace_pending = Some(rk);
+                    self.async_state.trace_result = None;
+                } else {
+                    tracing::warn!("Failed to parse resource key for trace command: {}", key);
+                    self.ui_state.status_message =
+                        Some(("Invalid resource key format".to_string(), true));
+                }
+            } else {
+                self.set_status_message(("No resource selected".to_string(), true));
+            }
+            return;
+        };
+
+        // Parse "<type>/<name>" (e.g. "kustomization/cabot-book").
+        let parts: Vec<&str> = trace_arg.split('/').collect();
+        if parts.len() == 2 {
+            use crate::models::FluxResourceKind;
+            // Normalize the resource type to its canonical kind name.
+            let lowered = parts[0].to_lowercase();
+            let resource_type = match FluxResourceKind::from_str_case_insensitive(parts[0]) {
+                Some(kind) => kind.as_str(),
+                None => match lowered.as_str() {
+                    "deployment" | "deploy" => "Deployment",
+                    "service" => "Service",
+                    "pod" => "Pod",
+                    _ => parts[0],
+                },
+            };
+            let namespace = self
+                .namespace()
+                .clone()
+                .unwrap_or_else(|| "default".to_string());
+            self.async_state.trace_pending = Some(ResourceKey::new(
+                resource_type.to_string(),
+                namespace,
+                parts[1].to_string(),
+            ));
+            self.async_state.trace_result = None;
+        } else {
+            self.set_status_message((
+                "Usage: :trace <resource-type>/<name> or :trace (for selected)".to_string(),
+                true,
+            ));
+        }
+    }
+
+    /// `:ctx [name]` — switch kube context, or open the context submenu / list
+    /// available contexts.
+    fn cmd_switch_context(&mut self, cmd: &str) {
+        let context_name = commands::extract_command_arg(cmd, "context")
+            .or_else(|| commands::extract_command_arg(cmd, "ctx"));
+
+        let Some(ctx) = context_name else {
+            // No argument: open the submenu, or list contexts as a fallback.
+            if !self.try_open_command_submenu(cmd) {
+                match crate::kube::list_contexts() {
+                    Ok(contexts) => {
+                        let current = self.context.clone();
+                        self.set_status_message((
+                            format!(
+                                "Available contexts: {}. Current: {}. Usage: :ctx <context-name>",
+                                contexts.join(", "),
+                                current
+                            ),
+                            false,
+                        ));
+                    }
+                    Err(e) => {
+                        self.set_status_message((format!("Failed to list contexts: {}", e), true))
+                    }
+                }
+            }
+            return;
+        };
+
+        // Mark the switch as pending; the main loop performs the reconnect.
+        self.pending_context_switch = Some(ctx.to_string());
+        self.set_status_message((format!("Switching to context '{}'...", ctx), false));
+    }
+
+    /// `:ns [name|all]` — switch the watched namespace, restarting watchers.
+    fn cmd_switch_namespace(&mut self, cmd: &str) {
+        let ns = commands::extract_command_arg(cmd, "namespace")
+            .or_else(|| commands::extract_command_arg(cmd, "ns"));
+        let new_namespace = match ns.as_deref() {
+            Some("all") | Some("-A") => None,
+            Some(name) => Some(name.to_string()),
+            None => return, // Showing the current namespace: nothing to do.
+        };
+
+        if self.namespace != new_namespace {
+            self.namespace = new_namespace.clone();
+
+            // Clear state; the restarted watchers repopulate it. Stale degraded
+            // state from the old watcher set would otherwise never clear.
+            self.state().clear();
+            self.resource_objects.clear();
+            self.controller_pods.clear();
+            self.degraded_watchers.clear();
+
+            if let Some(ref mut watcher) = self.watcher {
+                if let Err(e) = watcher.set_namespace(new_namespace) {
+                    tracing::warn!("Failed to switch namespace: {}", e);
+                    self.set_status_message((format!("Failed to switch namespace: {}", e), true));
+                }
+            }
+        }
+
+        self.reset_list_position();
+    }
+
+    /// `:healthy` — filter the list to healthy resources.
+    fn cmd_filter_healthy(&mut self, _cmd: &str) {
+        self.view_state.health_filter = HealthFilter::Healthy;
+        self.reset_list_position();
+        self.set_status_message(("Showing healthy resources only".to_string(), false));
+    }
+
+    /// `:unhealthy` — filter the list to unhealthy resources.
+    fn cmd_filter_unhealthy(&mut self, _cmd: &str) {
+        self.view_state.health_filter = HealthFilter::Unhealthy;
+        self.reset_list_position();
+        self.set_status_message(("Showing unhealthy resources only".to_string(), false));
+    }
+
+    /// `:favorites` — switch to the favorites view.
+    fn cmd_show_favorites(&mut self, _cmd: &str) {
+        self.view_state.current_view = View::ResourceFavorites;
+        self.reset_list_position();
+    }
+
+    /// `:all` — clear resource-type and health filters to show everything.
+    fn cmd_show_all(&mut self, _cmd: &str) {
+        if self.view_state.current_view == View::ResourceFavorites {
+            self.view_state.current_view = View::ResourceList;
+        }
+        if self.view_state.selected_resource_type.is_some() {
+            self.view_state.selected_resource_type = None;
+            self.invalidate_layout_cache(); // Resource type filter affects header display
+        }
+        if self.view_state.health_filter != HealthFilter::All {
+            self.view_state.health_filter = HealthFilter::All;
+            self.set_status_message(("Showing all resources".to_string(), false));
+        }
+        self.reset_list_position();
     }
 }
 
@@ -1523,6 +1587,68 @@ mod tests {
     }
 
     #[test]
+    fn table_command_healthy_sets_filter() {
+        let mut app = create_test_app(false);
+        app.ui_state.command_buffer = "healthy".to_string();
+
+        assert_eq!(app.execute_command(), None);
+        assert_eq!(app.view_state.health_filter, HealthFilter::Healthy);
+    }
+
+    #[test]
+    fn table_command_all_clears_filters() {
+        let mut app = create_test_app(false);
+        app.view_state.selected_resource_type = Some("Kustomization".to_string());
+        app.view_state.health_filter = HealthFilter::Unhealthy;
+        app.ui_state.command_buffer = "all".to_string();
+
+        assert_eq!(app.execute_command(), None);
+        assert_eq!(app.view_state.selected_resource_type, None);
+        assert_eq!(app.view_state.health_filter, HealthFilter::All);
+    }
+
+    #[test]
+    fn table_command_favorites_switches_view() {
+        let mut app = create_test_app(false);
+        app.ui_state.command_buffer = "favorites".to_string();
+
+        assert_eq!(app.execute_command(), None);
+        assert_eq!(app.view_state.current_view, View::ResourceFavorites);
+    }
+
+    #[test]
+    fn quit_command_returns_true() {
+        let mut app = create_test_app(false);
+        app.ui_state.command_buffer = "q".to_string();
+        assert_eq!(app.execute_command(), Some(true));
+    }
+
+    #[test]
+    fn unknown_command_reports_error() {
+        let mut app = create_test_app(false);
+        app.ui_state.command_buffer = "definitely-not-a-command".to_string();
+
+        assert_eq!(app.execute_command(), None);
+        let (msg, is_error) = app.ui_state.status_message.clone().unwrap();
+        assert!(is_error);
+        assert!(msg.contains("Unknown command"));
+    }
+
+    #[test]
+    fn readonly_command_toggles_mode() {
+        let mut app = create_test_app(false);
+        assert!(!app.config.read_only);
+
+        app.ui_state.command_buffer = "readonly".to_string();
+        assert_eq!(app.execute_command(), None);
+        assert!(app.config.read_only);
+
+        app.ui_state.command_buffer = "readonly".to_string();
+        assert_eq!(app.execute_command(), None);
+        assert!(!app.config.read_only);
+    }
+
+    #[test]
     fn test_sort_keys_in_list_view() {
         use crate::tui::app::state::SortField;
         let mut app = create_test_app(false);
@@ -1611,5 +1737,140 @@ mod tests {
         app.handle_key(make_key(KeyCode::Char('/')));
         assert!(app.view_state.filter_mode);
         assert!(!app.view_state.text_search.input_mode);
+    }
+
+    // --- Graph view focus navigation -------------------------------------
+
+    fn graph_node(
+        kind: &str,
+        name: &str,
+        node_type: crate::trace::NodeType,
+    ) -> crate::trace::GraphNode {
+        crate::trace::GraphNode {
+            id: format!("{}:flux-system:{}", kind, name),
+            kind: kind.to_string(),
+            name: name.to_string(),
+            namespace: "flux-system".to_string(),
+            node_type,
+            ready: None,
+            position: None,
+            description: None,
+        }
+    }
+
+    /// Build a small graph: a source (watched), the object (watched), and a
+    /// workload group (aggregate). Returns the app already on the graph view.
+    fn app_on_graph() -> App {
+        use crate::trace::{NodeType, ResourceGraph};
+
+        let mut app = create_test_app(false);
+        add_resource(&mut app); // Kustomization:flux-system:my-kustomization (watched)
+
+        let mut graph = ResourceGraph::new();
+        // idx 0: object (layer 3) — matches the watched resource
+        graph.add_node(graph_node(
+            "Kustomization",
+            "my-kustomization",
+            NodeType::Object,
+        ));
+        // idx 1: source (layer 1) — not in the watched state
+        graph.add_node(graph_node("GitRepository", "my-repo", NodeType::Source));
+        // idx 2: workload group (layer 5) — aggregate, not navigable
+        graph.add_node(graph_node(
+            "Workloads",
+            "Workloads (1)",
+            NodeType::WorkloadGroup,
+        ));
+
+        app.set_graph_result(graph);
+        app.view_state.current_view = View::ResourceGraph;
+        app
+    }
+
+    #[test]
+    fn graph_focus_starts_on_object_node() {
+        let app = app_on_graph();
+        // object_node_index() == 0 in app_on_graph's graph
+        assert_eq!(app.view_state.graph_focus_index, Some(0));
+    }
+
+    #[test]
+    fn graph_j_k_move_focus_in_visual_order() {
+        let mut app = app_on_graph();
+        // Visual order by layer: source(1), object(0), workload group(2).
+        // Focus starts on the object (pos 1 in that order).
+        app.handle_key(make_key(KeyCode::Char('j'))); // down -> workload group
+        assert_eq!(app.view_state.graph_focus_index, Some(2));
+
+        app.handle_key(make_key(KeyCode::Char('j'))); // clamp at the bottom
+        assert_eq!(app.view_state.graph_focus_index, Some(2));
+
+        app.handle_key(make_key(KeyCode::Char('k'))); // up -> object
+        assert_eq!(app.view_state.graph_focus_index, Some(0));
+        app.handle_key(make_key(KeyCode::Char('k'))); // up -> source
+        assert_eq!(app.view_state.graph_focus_index, Some(1));
+        app.handle_key(make_key(KeyCode::Char('k'))); // clamp at the top
+        assert_eq!(app.view_state.graph_focus_index, Some(1));
+    }
+
+    #[test]
+    fn graph_enter_navigates_into_watched_node_and_esc_returns_to_graph() {
+        let mut app = app_on_graph();
+        // Focus is on the object node, which is in the watched state.
+        app.handle_key(make_key(KeyCode::Enter));
+
+        assert_eq!(app.view_state.current_view, View::ResourceDetail);
+        assert_eq!(
+            app.selection_state.selected_resource_key.as_deref(),
+            Some("Kustomization:flux-system:my-kustomization")
+        );
+        assert_eq!(app.view_state.detail_back_view, Some(View::ResourceGraph));
+
+        // Esc from the detail view returns to the graph, not the list.
+        app.handle_key(make_key(KeyCode::Esc));
+        assert_eq!(app.view_state.current_view, View::ResourceGraph);
+        assert_eq!(app.view_state.detail_back_view, None);
+        // Focus is preserved so the user lands back where they were.
+        assert_eq!(app.view_state.graph_focus_index, Some(0));
+    }
+
+    #[test]
+    fn graph_enter_on_unwatched_node_shows_message_and_stays() {
+        let mut app = app_on_graph();
+        app.view_state.graph_focus_index = Some(1); // the source, not in state
+
+        app.handle_key(make_key(KeyCode::Enter));
+
+        assert_eq!(app.view_state.current_view, View::ResourceGraph);
+        assert!(app.ui_state.status_message.is_some());
+    }
+
+    #[test]
+    fn graph_enter_on_aggregate_node_shows_message_and_stays() {
+        let mut app = app_on_graph();
+        app.view_state.graph_focus_index = Some(2); // the workload group aggregate
+
+        app.handle_key(make_key(KeyCode::Enter));
+
+        assert_eq!(app.view_state.current_view, View::ResourceGraph);
+        assert!(app.ui_state.status_message.is_some());
+    }
+
+    #[test]
+    fn list_enter_clears_graph_back_target() {
+        let mut app = app_on_graph();
+        // Simulate having drilled in from the graph earlier.
+        app.view_state.detail_back_view = Some(View::ResourceGraph);
+
+        // Now go back to the list and open a resource the normal way.
+        app.view_state.current_view = View::ResourceList;
+        app.view_state.selected_index = 0;
+        app.handle_key(make_key(KeyCode::Enter));
+
+        assert_eq!(app.view_state.current_view, View::ResourceDetail);
+        // Back target was reset, so Esc here returns to the list.
+        assert_eq!(app.view_state.detail_back_view, None);
+        app.handle_key(make_key(KeyCode::Esc));
+        assert_eq!(app.view_state.current_view, View::ResourceList);
     }
 }

--- a/src/tui/app/rendering.rs
+++ b/src/tui/app/rendering.rs
@@ -469,6 +469,7 @@ impl App {
                         &self.async_state.graph_result,
                         &self.async_state.graph_pending,
                         &mut self.view_state.graph_scroll_offset,
+                        self.view_state.graph_focus_index,
                         &self.theme,
                     );
                 }

--- a/src/tui/app/state.rs
+++ b/src/tui/app/state.rs
@@ -22,6 +22,52 @@ pub enum View {
     Help,
 }
 
+impl View {
+    /// Mutable line-scroll offset for the simple text/log views that scroll one
+    /// line at a time. Returns `None` for views with bespoke navigation: lists
+    /// use a selection index and the graph view uses node focus. This is the
+    /// single place that maps a view to its scroll field, so the scroll handlers
+    /// don't each repeat the per-view match.
+    pub fn scroll_offset_mut(self, vs: &mut ViewState) -> Option<&mut usize> {
+        match self {
+            View::ResourceYAML => Some(&mut vs.yaml_scroll_offset),
+            View::ResourceDescribe => Some(&mut vs.describe_scroll_offset),
+            View::ResourceTrace => Some(&mut vs.trace_scroll_offset),
+            View::ResourceHistory => Some(&mut vs.history_scroll_offset),
+            _ => None,
+        }
+    }
+
+    /// Whether this is a list-style view (the main resource list or favorites)
+    /// from which resources are selected and opened.
+    pub fn is_list_view(self) -> bool {
+        matches!(self, View::ResourceList | View::ResourceFavorites)
+    }
+
+    /// Whether `/` opens an in-view text search (YAML/describe/trace) rather than
+    /// the resource-list filter.
+    pub fn is_text_search_view(self) -> bool {
+        matches!(
+            self,
+            View::ResourceYAML | View::ResourceDescribe | View::ResourceTrace
+        )
+    }
+
+    /// Whether this is a nested detail-style view opened from a list — i.e. one
+    /// that Back/Esc should pop back to the list (or graph) rather than quit.
+    pub fn is_nested_view(self) -> bool {
+        matches!(
+            self,
+            View::ResourceDetail
+                | View::ResourceDescribe
+                | View::ResourceYAML
+                | View::ResourceTrace
+                | View::ResourceHistory
+                | View::ResourceGraph
+        )
+    }
+}
+
 /// Connection status to the Kubernetes API server.
 ///
 /// Drives the startup connection-error screen: while `Connecting` the splash is
@@ -144,8 +190,15 @@ pub struct ViewState {
     pub history_scroll_offset: usize,
     /// Scroll offset for graph view
     pub graph_scroll_offset: usize,
+    /// Index (into the graph's node list) of the currently focused graph node.
+    /// `None` until a graph is built; set to the object node when one loads.
+    pub graph_focus_index: Option<usize>,
     /// Track previous list view for navigation (ResourceList or ResourceFavorites)
     pub previous_list_view: View,
+    /// When the detail view was entered by drilling into a node from the graph,
+    /// this holds `ResourceGraph` so that Back returns to the graph instead of
+    /// all the way to the list. Consumed (taken) on the next Back.
+    pub detail_back_view: Option<View>,
     /// Active submenu state (if a submenu is currently being displayed)
     pub submenu_state: Option<SubmenuState>,
     /// Original theme name when previewing themes in submenu (for restoration on cancel)
@@ -175,7 +228,9 @@ impl Default for ViewState {
             trace_scroll_offset: 0,
             history_scroll_offset: 0,
             graph_scroll_offset: 0,
+            graph_focus_index: None,
             previous_list_view: View::ResourceList,
+            detail_back_view: None,
             submenu_state: None,
             preview_original_theme: None,
             page_size: 10,
@@ -384,5 +439,51 @@ impl ControllerPodState {
     /// This represents the overall Flux release version, not individual controller versions
     pub fn get_flux_version(&self) -> Option<&str> {
         self.flux_bundle_version.as_deref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn view_classifiers_partition_views_as_expected() {
+        assert!(View::ResourceList.is_list_view());
+        assert!(View::ResourceFavorites.is_list_view());
+        assert!(!View::ResourceGraph.is_list_view());
+
+        assert!(View::ResourceYAML.is_text_search_view());
+        assert!(View::ResourceDescribe.is_text_search_view());
+        assert!(View::ResourceTrace.is_text_search_view());
+        assert!(!View::ResourceHistory.is_text_search_view());
+        assert!(!View::ResourceList.is_text_search_view());
+
+        for v in [
+            View::ResourceDetail,
+            View::ResourceDescribe,
+            View::ResourceYAML,
+            View::ResourceTrace,
+            View::ResourceHistory,
+            View::ResourceGraph,
+        ] {
+            assert!(v.is_nested_view(), "{v:?} should be a nested view");
+        }
+        assert!(!View::ResourceList.is_nested_view());
+        assert!(!View::ResourceFavorites.is_nested_view());
+    }
+
+    #[test]
+    fn scroll_offset_mut_targets_the_right_field() {
+        let mut vs = ViewState::default();
+
+        // Text/log views expose a line-scroll offset.
+        *View::ResourceYAML.scroll_offset_mut(&mut vs).unwrap() = 7;
+        assert_eq!(vs.yaml_scroll_offset, 7);
+        *View::ResourceHistory.scroll_offset_mut(&mut vs).unwrap() = 3;
+        assert_eq!(vs.history_scroll_offset, 3);
+
+        // List and graph views have bespoke navigation, so no scroll offset.
+        assert!(View::ResourceList.scroll_offset_mut(&mut vs).is_none());
+        assert!(View::ResourceGraph.scroll_offset_mut(&mut vs).is_none());
     }
 }

--- a/src/tui/views/graph.rs
+++ b/src/tui/views/graph.rs
@@ -9,7 +9,7 @@ use crate::watcher::ResourceKey;
 use ratatui::{
     Frame,
     layout::{Margin, Rect},
-    style::{Modifier, Style},
+    style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph},
 };
@@ -21,7 +21,8 @@ pub fn render_resource_graph(
     _selected_resource_key: &Option<String>,
     graph_result: &Option<ResourceGraph>,
     graph_pending: &Option<ResourceKey>,
-    scroll_offset: &mut usize, // Line-based scroll offset (like YAML view)
+    scroll_offset: &mut usize,  // Line-based scroll offset (like YAML view)
+    focus_index: Option<usize>, // Index of the keyboard-focused node, if any
     theme: &Theme,
 ) {
     let outer_block = crate::tui::views::helpers::create_themed_block("Resource Graph", theme);
@@ -81,10 +82,98 @@ pub fn render_resource_graph(
     } else {
         0
     };
+
+    // Auto-scroll so the focused node stays fully on screen. Positions are only
+    // known after layout, so this runs here rather than in the event handler.
+    if let Some((node_y, node_height)) = focus_index.and_then(|idx| {
+        graph.nodes.get(idx).and_then(|node| {
+            node.position.map(|(_, y)| {
+                (
+                    y as usize,
+                    calculate_node_size(node, inner_area.width).1 as usize,
+                )
+            })
+        })
+    }) {
+        if node_y < *scroll_offset {
+            *scroll_offset = node_y;
+        } else if node_y + node_height > *scroll_offset + visible_height {
+            *scroll_offset = (node_y + node_height).saturating_sub(visible_height);
+        }
+    }
+
     *scroll_offset = (*scroll_offset).min(max_scroll);
 
     // Render graph using improved layout with line-based scrolling
-    render_graph_nodes_and_edges(f, inner_area, &graph, *scroll_offset, theme);
+    render_graph_nodes_and_edges(f, inner_area, &graph, *scroll_offset, focus_index, theme);
+}
+
+/// Pure geometry for one parent→children connector, in scroll-adjusted,
+/// area-relative cell coordinates. Separated from drawing so it can be unit
+/// tested without a `Frame`.
+struct FanoutRoute {
+    parent_center_x: u16,
+    parent_bottom_y: u16,
+    /// Each child's connection point: `(center_x, top_y)`.
+    children: Vec<(u16, u16)>,
+    relationship: RelationshipType,
+}
+
+/// Compute the connector route for every parent that has placed children.
+///
+/// Pure function of the (already laid-out) graph, the available width and the
+/// scroll offset — no theme or `Frame` involved — so the geometry is testable in
+/// isolation. Parents and children are visited in node/edge insertion order, so
+/// the result is deterministic.
+fn fanout_routes(graph: &ResourceGraph, area_width: u16, scroll_offset: u16) -> Vec<FanoutRoute> {
+    let mut routes = Vec::new();
+
+    for parent in &graph.nodes {
+        let Some((px, py)) = parent.position else {
+            continue;
+        };
+
+        let mut children = Vec::new();
+        let mut relationship = None;
+        for edge in &graph.edges {
+            if edge.from != parent.id {
+                continue;
+            }
+            if let Some(child) = graph
+                .node_index
+                .get(&edge.to)
+                .and_then(|&i| graph.nodes.get(i))
+            {
+                if let Some((cx, cy)) = child.position {
+                    let center = cx + child.render_width(area_width) / 2;
+                    children.push((center, cy.saturating_sub(scroll_offset)));
+                    relationship.get_or_insert(edge.relationship);
+                }
+            }
+        }
+
+        let Some(relationship) = relationship else {
+            continue; // No placed children for this parent.
+        };
+
+        routes.push(FanoutRoute {
+            parent_center_x: px + parent.render_width(area_width) / 2,
+            parent_bottom_y: (py + parent.render_height()).saturating_sub(scroll_offset),
+            children,
+            relationship,
+        });
+    }
+
+    routes
+}
+
+/// Map an edge relationship to its connector color.
+fn edge_color(relationship: RelationshipType, theme: &Theme) -> Color {
+    match relationship {
+        RelationshipType::SourcedFrom => theme.status_ready,
+        RelationshipType::ManagedBy => theme.text_primary,
+        RelationshipType::Owns => theme.text_label,
+    }
 }
 
 /// Render graph nodes and edges with improved layout
@@ -92,511 +181,179 @@ fn render_graph_nodes_and_edges(
     f: &mut Frame,
     area: Rect,
     graph: &ResourceGraph,
-    scroll_offset: usize, // Line-based scroll offset
+    scroll_offset: usize,       // Line-based scroll offset
+    focus_index: Option<usize>, // Index of the keyboard-focused node, if any
     theme: &Theme,
 ) {
-    // Render edges first (so they appear behind nodes) using Unicode box drawing
-    // Group edges by parent node to render T-junctions properly
-    use std::collections::HashMap;
-    let mut edges_by_parent: HashMap<String, Vec<(&crate::trace::GraphEdge, usize, usize)>> =
-        HashMap::new();
-
-    for edge in &graph.edges {
-        if let (Some(&from_idx), Some(&to_idx)) = (
-            graph.node_index.get(&edge.from),
-            graph.node_index.get(&edge.to),
-        ) {
-            if let (Some(from_node), Some(to_node)) =
-                (graph.nodes.get(from_idx), graph.nodes.get(to_idx))
-            {
-                if from_node.position.is_some() && to_node.position.is_some() {
-                    edges_by_parent
-                        .entry(edge.from.clone())
-                        .or_default()
-                        .push((edge, from_idx, to_idx));
-                }
-            }
-        }
-    }
-
-    // Render grouped edges (for T-junctions) and individual edges
     let scroll_offset_u16 = scroll_offset as u16;
-    for (parent_id, child_edges) in &edges_by_parent {
-        if let Some(&parent_idx) = graph.node_index.get(parent_id) {
-            if let Some(parent_node) = graph.nodes.get(parent_idx) {
-                if let Some((parent_x, parent_y)) = parent_node.position {
-                    // Check if children are side-by-side (need T-junction)
-                    let child_nodes: Vec<(
-                        &crate::trace::GraphEdge,
-                        &crate::trace::GraphNode,
-                        (u16, u16),
-                    )> = child_edges
-                        .iter()
-                        .filter_map(|(edge, _, to_idx)| {
-                            graph
-                                .nodes
-                                .get(*to_idx)
-                                .and_then(|n| n.position.map(|pos| (*edge, n, pos)))
-                        })
-                        .collect();
 
-                    if child_nodes.len() > 1 {
-                        // Check if children are side-by-side
-                        let (parent_w, _parent_h) = calculate_node_size(parent_node, area.width);
-                        let _parent_center_x = parent_x + parent_w / 2;
-
-                        let child_centers: Vec<(u16, u16, u16)> = child_nodes
-                            .iter()
-                            .map(|(_, child_node, (cx, _cy))| {
-                                let (child_w, _child_h) =
-                                    calculate_node_size(child_node, area.width);
-                                let child_center_x = *cx + child_w / 2;
-                                (child_center_x, *cx, child_w)
-                            })
-                            .collect();
-
-                        // Check if children are side-by-side
-                        let min_x = child_centers
-                            .iter()
-                            .map(|(cx, _, _)| *cx)
-                            .min()
-                            .unwrap_or(0);
-                        let max_x = child_centers
-                            .iter()
-                            .map(|(cx, _, _)| *cx)
-                            .max()
-                            .unwrap_or(0);
-                        let avg_width: u16 = child_centers.iter().map(|(_, _, w)| *w).sum::<u16>()
-                            / child_centers.len() as u16;
-                        let is_side_by_side = max_x.saturating_sub(min_x) > avg_width;
-
-                        if is_side_by_side {
-                            // Render T-junction: vertical down, horizontal branch, vertical up to each child
-                            render_t_junction(
-                                f,
-                                area,
-                                parent_x,
-                                parent_y,
-                                parent_node,
-                                &child_nodes,
-                                scroll_offset_u16,
-                                theme,
-                            );
-                        } else {
-                            // Render individual edges (vertically aligned)
-                            for (edge, child_node, (child_x, child_y)) in &child_nodes {
-                                render_edge_improved(
-                                    f,
-                                    area,
-                                    parent_x,
-                                    parent_y,
-                                    *child_x,
-                                    *child_y,
-                                    parent_node,
-                                    child_node,
-                                    edge.relationship,
-                                    scroll_offset_u16,
-                                    theme,
-                                );
-                            }
-                        }
-                    } else {
-                        // Single child - render normally
-                        for (edge, _, to_idx) in child_edges {
-                            if let (Some(child_node), Some((child_x, child_y))) =
-                                (graph.nodes.get(*to_idx), graph.nodes[*to_idx].position)
-                            {
-                                render_edge_improved(
-                                    f,
-                                    area,
-                                    parent_x,
-                                    parent_y,
-                                    child_x,
-                                    child_y,
-                                    parent_node,
-                                    child_node,
-                                    edge.relationship,
-                                    scroll_offset_u16,
-                                    theme,
-                                );
-                            }
-                        }
-                    }
-                }
-            }
-        }
+    // Render edges first (behind the nodes) as fan-outs: a trunk down from the
+    // parent, a horizontal branch just above its children, then a short drop into
+    // each child. Routing every parent (one child or many) through the same
+    // renderer keeps the connector lines consistent and unambiguous.
+    for route in fanout_routes(graph, area.width, scroll_offset_u16) {
+        render_fanout(
+            f,
+            area,
+            route.parent_center_x,
+            route.parent_bottom_y,
+            &route.children,
+            edge_color(route.relationship, theme),
+        );
     }
 
     // Render nodes - only those within visible range (like YAML view)
     let visible_height = area.height as usize;
-    let scroll_offset_u16 = scroll_offset as u16;
 
-    for node in &graph.nodes {
+    for (idx, node) in graph.nodes.iter().enumerate() {
         if let Some((x, y)) = node.position {
             // Only render if node's Y position is within visible range
             if y >= scroll_offset_u16 && y < scroll_offset_u16 + visible_height as u16 {
-                render_node_text(f, area, x, y, node, scroll_offset_u16, theme);
+                let is_focused = focus_index == Some(idx);
+                render_node_text(f, area, x, y, node, scroll_offset_u16, is_focused, theme);
             }
         }
     }
 }
 
 /// Calculate node dimensions based on content
+/// Rendered (width, height) of a node. Thin adapter over the single source of
+/// truth on [`crate::trace::GraphNode`] so layout and drawing always agree.
 fn calculate_node_size(node: &crate::trace::GraphNode, area_width: u16) -> (u16, u16) {
-    let name_len = node.name.len() as u16;
-    let kind_len = node.kind.len() as u16;
-    let desc_len = node
-        .description
-        .as_ref()
-        .map(|d| d.len() as u16)
-        .unwrap_or(0);
-    let max_content = name_len.max(kind_len).max(desc_len);
-    let width = max_content.clamp(30, 60).min(area_width.saturating_sub(4));
-
-    // Calculate height: title section + content + borders
-    // For WorkloadGroup/ResourceGroup: name (1) + separator (1) + borders (2) = 4 base
-    // For other nodes: kind label (1) + name (1) + separator (1) + borders (2) = 5 base
-    let mut height = if matches!(
-        node.node_type,
-        NodeType::WorkloadGroup | NodeType::ResourceGroup
-    ) {
-        4u16 // name + separator + borders
-    } else {
-        5u16 // kind label + name + separator + borders
-    };
-
-    // Workload nodes have: kind label + name + separator + description (replica count) + namespace subtitle
-    if matches!(node.node_type, NodeType::Workload) {
-        if node.description.is_some() {
-            height += 2; // description line + namespace subtitle
-        }
-    } else if matches!(node.node_type, NodeType::WorkloadGroup) {
-        // Workload group nodes show each workload as 3-4 lines (kind, name, status, optional namespace) + blank lines between
-        if let Some(ref desc) = node.description {
-            let workload_lines: Vec<&str> = desc.lines().collect();
-            let workload_count = workload_lines.len();
-
-            if workload_count > 0 {
-                // Check if namespaces differ
-                let show_namespace = if workload_count > 1 {
-                    let first_namespace = workload_lines[0].split('|').nth(2).unwrap_or("");
-                    !workload_lines
-                        .iter()
-                        .all(|line| line.split('|').nth(2).unwrap_or("") == first_namespace)
-                } else {
-                    false
-                };
-
-                // Each workload: kind (1) + name (1) + status (1) + namespace (0-1) = 3-4 lines
-                // Plus 1 blank line between workloads (workload_count - 1 blank lines)
-                let lines_per_workload = if show_namespace { 4 } else { 3 };
-                let blank_lines = workload_count.saturating_sub(1);
-                height += (workload_count * lines_per_workload + blank_lines) as u16;
-            }
-        }
-    } else if matches!(node.node_type, NodeType::ResourceGroup) {
-        // Resource group nodes show each resource kind on a separate line
-        if let Some(ref desc) = node.description {
-            // Count the number of resource items (separated by ", ")
-            let item_count = desc.matches(", ").count() + 1;
-            height += item_count as u16;
-        }
-    } else {
-        if node.description.is_some() {
-            height += 1; // description line
-        }
-        if node.ready.is_some() {
-            height += 1; // status line
-        }
-    }
-
-    (width, height)
+    (node.render_width(area_width), node.render_height())
 }
 
-/// Render a T-junction for side-by-side child nodes
-fn render_t_junction(
-    f: &mut Frame,
-    area: Rect,
-    parent_x: u16,
-    parent_y: u16,
-    parent_node: &crate::trace::GraphNode,
-    child_nodes: &[(
-        &crate::trace::GraphEdge,
-        &crate::trace::GraphNode,
-        (u16, u16),
-    )],
-    scroll_offset: u16,
-    theme: &Theme,
-) {
-    let (parent_w, parent_h) = calculate_node_size(parent_node, area.width);
-
-    // Adjust parent position for scroll
-    let fx = parent_x;
-    let fy = parent_y.saturating_sub(scroll_offset);
-
-    let parent_center_x = fx + parent_w / 2;
-    let parent_bottom_y = fy + parent_h;
-
-    // Get child positions and centers
-    let mut child_info: Vec<(u16, u16, u16, u16, RelationshipType)> = Vec::new();
-    for (edge, child_node, (child_x, child_y)) in child_nodes {
-        let (child_w, child_h) = calculate_node_size(child_node, area.width);
-        let tx = child_x;
-        let ty = child_y.saturating_sub(scroll_offset);
-        let child_center_x = tx + child_w / 2;
-        let child_top_y = ty;
-        child_info.push((
-            child_center_x,
-            child_top_y,
-            child_w,
-            child_h,
-            edge.relationship,
-        ));
+/// Draw a vertical run of `height` cells at column `x`, clipped to `area`.
+fn draw_vline(f: &mut Frame, area: Rect, x: u16, y: u16, height: u16, color: Color) {
+    if height == 0 || x >= area.width || y >= area.height {
+        return;
     }
-
-    // Determine edge color (use first edge's relationship)
-    let edge_color = match child_info.first().map(|(_, _, _, _, r)| r) {
-        Some(RelationshipType::SourcedFrom) => theme.status_ready,
-        Some(RelationshipType::ManagedBy) => theme.text_primary,
-        Some(RelationshipType::Owns) => theme.text_label,
-        None => theme.text_label,
+    let h = height.min(area.height - y);
+    let rect = Rect {
+        x: area.x + x,
+        y: area.y + y,
+        width: 1,
+        height: h,
     };
+    let lines: Vec<Line> = (0..h).map(|_| Line::from("│")).collect();
+    f.render_widget(
+        Paragraph::new(lines).style(Style::default().fg(color)),
+        rect,
+    );
+}
 
-    // Find leftmost and rightmost children
-    let leftmost_x = child_info
-        .iter()
-        .map(|(cx, _, _, _, _)| *cx)
-        .min()
-        .unwrap_or(0);
-    let rightmost_x = child_info
-        .iter()
-        .map(|(cx, _, _, _, _)| *cx)
-        .max()
-        .unwrap_or(0);
-
-    // Branch Y is 1 line below parent
-    let branch_y = parent_bottom_y + 1;
-
-    // Draw vertical line from parent bottom to branch point
-    if parent_center_x < area.width && branch_y > parent_bottom_y {
-        let vertical_start_y = parent_bottom_y;
-        let vertical_end_y = branch_y.min(area.height);
-        if vertical_end_y > vertical_start_y {
-            let vertical_height = vertical_end_y.saturating_sub(vertical_start_y);
-            if vertical_height > 0 {
-                let vertical_area = Rect {
-                    x: area.x + parent_center_x,
-                    y: area.y + vertical_start_y,
-                    width: 1,
-                    height: vertical_height,
-                };
-                let mut lines = Vec::new();
-                for _ in 0..vertical_area.height {
-                    lines.push(Line::from("│"));
-                }
-                let paragraph = Paragraph::new(lines).style(Style::default().fg(edge_color));
-                f.render_widget(paragraph, vertical_area);
-            }
-        }
+/// Draw a pre-built run of box-drawing glyphs starting at column `x`, clipped to
+/// `area`. The caller composes the glyphs (with junctions) so overlapping cells
+/// don't fight each other.
+fn draw_hline(f: &mut Frame, area: Rect, x: u16, y: u16, glyphs: &str, color: Color) {
+    let width = glyphs.chars().count() as u16;
+    if width == 0 || x >= area.width || y >= area.height {
+        return;
     }
+    let w = width.min(area.width - x);
+    let text: String = glyphs.chars().take(w as usize).collect();
+    let rect = Rect {
+        x: area.x + x,
+        y: area.y + y,
+        width: w,
+        height: 1,
+    };
+    f.render_widget(Paragraph::new(text).style(Style::default().fg(color)), rect);
+}
 
-    // Draw horizontal branch from leftmost to rightmost child
-    if branch_y < area.height {
-        let horizontal_start_x = leftmost_x.min(parent_center_x);
-        let horizontal_end_x = rightmost_x.max(parent_center_x).min(area.width);
-        let horizontal_width = horizontal_end_x.saturating_sub(horizontal_start_x);
-
-        if horizontal_width > 0 && horizontal_start_x < area.width {
-            let horizontal_area = Rect {
-                x: area.x + horizontal_start_x,
-                y: area.y + branch_y,
-                width: horizontal_width,
-                height: 1,
-            };
-
-            let horizontal_line = "─".repeat(horizontal_area.width as usize);
-            let paragraph = Paragraph::new(horizontal_line).style(Style::default().fg(edge_color));
-            f.render_widget(paragraph, horizontal_area);
+/// Pick the box-drawing glyph for a cell from which sides connect.
+fn box_glyph(up: bool, down: bool, left: bool, right: bool) -> char {
+    match (up, down, left, right) {
+        (true, true, true, true) => '┼',
+        (false, true, true, true) => '┬',
+        (true, false, true, true) => '┴',
+        (true, true, true, false) => '┤',
+        (true, true, false, true) => '├',
+        (false, true, false, true) => '┌',
+        (false, true, true, false) => '┐',
+        (true, false, false, true) => '└',
+        (true, false, true, false) => '┘',
+        (true, true, false, false) | (true, false, false, false) | (false, true, false, false) => {
+            '│'
         }
-    }
-
-    // Draw vertical lines from branch to each child
-    for (child_center_x, child_top_y, _child_w, _child_h, _relationship) in &child_info {
-        let vertical_start_y = branch_y + 1;
-        let vertical_end_y = (*child_top_y).min(area.height);
-
-        if vertical_start_y < vertical_end_y && *child_center_x < area.width {
-            let vertical_height = vertical_end_y.saturating_sub(vertical_start_y);
-            if vertical_height > 0 {
-                let vertical_area = Rect {
-                    x: area.x + *child_center_x,
-                    y: area.y + vertical_start_y,
-                    width: 1,
-                    height: vertical_height,
-                };
-                let mut lines = Vec::new();
-                for _ in 0..vertical_area.height {
-                    lines.push(Line::from("│"));
-                }
-                let paragraph = Paragraph::new(lines).style(Style::default().fg(edge_color));
-                f.render_widget(paragraph, vertical_area);
-            }
-        }
+        _ => '─',
     }
 }
 
-/// Render an edge between two nodes with improved Unicode box drawing
-fn render_edge_improved(
+/// Render a parent→children fan-out: a trunk down from the parent, a horizontal
+/// branch sitting just above the topmost child (with proper junction glyphs),
+/// then a short drop into each child. The single-child case collapses to a plain
+/// vertical line, so every connector in the graph is drawn the same way.
+fn render_fanout(
     f: &mut Frame,
     area: Rect,
-    from_x: u16,
-    from_y: u16,
-    to_x: u16,
-    to_y: u16,
-    from_node: &crate::trace::GraphNode,
-    to_node: &crate::trace::GraphNode,
-    relationship: RelationshipType,
-    scroll_offset: u16,
-    theme: &Theme,
+    parent_center_x: u16,
+    parent_bottom_y: u16,
+    children: &[(u16, u16)], // (center_x, top_y), already scroll-adjusted
+    color: Color,
 ) {
-    let (from_w, from_h) = calculate_node_size(from_node, area.width);
-    let (to_w, _to_h) = calculate_node_size(to_node, area.width);
-
-    // Adjust positions for scroll offset
-    let fx = from_x;
-    let fy = from_y.saturating_sub(scroll_offset);
-    let tx = to_x;
-    let ty = to_y.saturating_sub(scroll_offset);
-
-    // Calculate connection points (center bottom of from, center top of to)
-    let from_center_x = fx + from_w / 2;
-    let from_bottom_y = fy + from_h;
-    let to_center_x = tx + to_w / 2;
-    let to_top_y = ty;
-
-    // Only skip if completely off-screen (allow partial visibility for edges)
-    // Edges can extend beyond visible area - we'll clip them during rendering
-    if from_center_x >= area.width && to_center_x >= area.width {
-        return; // Both nodes completely off-screen horizontally
-    }
-    if from_bottom_y >= area.height && to_top_y >= area.height {
-        return; // Both nodes completely off-screen vertically
+    if children.is_empty() {
+        return;
     }
 
-    let edge_color = match relationship {
-        RelationshipType::SourcedFrom => theme.status_ready,
-        RelationshipType::ManagedBy => theme.text_primary,
-        RelationshipType::Owns => theme.text_label,
-    };
+    let min_top = children.iter().map(|(_, t)| *t).min().unwrap_or(0);
 
-    // Check if nodes are side-by-side (horizontal connection needed)
-    let horizontal_distance = from_center_x.abs_diff(to_center_x);
-
-    let is_side_by_side = horizontal_distance > from_w / 2 + to_w / 2;
-
-    if is_side_by_side {
-        // Nodes are side-by-side: draw vertical line down, then horizontal branch, then vertical to target
-        let branch_y = from_bottom_y + 1; // Start branch 1 line below from node
-
-        // Draw vertical line from bottom of from_node to branch point
-        // Clip to visible area
-        let vertical_start_y = from_bottom_y;
-        let vertical_end_y = branch_y.min(area.height);
-        if vertical_end_y > vertical_start_y && from_center_x < area.width {
-            let vertical_height = vertical_end_y.saturating_sub(vertical_start_y);
-            if vertical_height > 0 {
-                let vertical_area = Rect {
-                    x: area.x + from_center_x,
-                    y: area.y + vertical_start_y,
-                    width: 1,
-                    height: vertical_height,
-                };
-                let mut lines = Vec::new();
-                for _ in 0..vertical_area.height {
-                    lines.push(Line::from("│"));
-                }
-                let paragraph = Paragraph::new(lines).style(Style::default().fg(edge_color));
-                f.render_widget(paragraph, vertical_area);
+    // No room for a branch row between parent and children: connect each child
+    // straight up to the parent's bottom edge instead.
+    if min_top <= parent_bottom_y {
+        for &(cx, top) in children {
+            if top > parent_bottom_y {
+                draw_vline(f, area, cx, parent_bottom_y, top - parent_bottom_y, color);
             }
         }
+        return;
+    }
 
-        // Draw horizontal line from from_center_x to to_center_x at branch_y
-        // This forms the horizontal branch of the T-junction
-        // Clip to visible area but ensure we draw if any part is visible
-        if branch_y < area.height {
-            let horizontal_start_x = from_center_x.min(to_center_x);
-            let horizontal_end_x = from_center_x.max(to_center_x).min(area.width);
-            let horizontal_width = horizontal_end_x.saturating_sub(horizontal_start_x);
+    let branch_y = min_top - 1;
 
-            if horizontal_width > 0 && horizontal_start_x < area.width {
-                let horizontal_area = Rect {
-                    x: area.x + horizontal_start_x,
-                    y: area.y + branch_y,
-                    width: horizontal_width,
-                    height: 1,
-                };
+    // Horizontal extent spans the trunk and every child center.
+    let mut left = parent_center_x;
+    let mut right = parent_center_x;
+    for &(cx, _) in children {
+        left = left.min(cx);
+        right = right.max(cx);
+    }
+    if right >= area.width {
+        right = area.width.saturating_sub(1);
+    }
+    if left > right {
+        return;
+    }
 
-                // Create horizontal line with ─ characters
-                let horizontal_line = "─".repeat(horizontal_area.width as usize);
-                let paragraph =
-                    Paragraph::new(horizontal_line).style(Style::default().fg(edge_color));
-                f.render_widget(paragraph, horizontal_area);
-            }
-        }
+    // 1. Trunk from the parent's bottom down to the branch row.
+    if branch_y > parent_bottom_y {
+        draw_vline(
+            f,
+            area,
+            parent_center_x,
+            parent_bottom_y,
+            branch_y - parent_bottom_y,
+            color,
+        );
+    }
 
-        // Draw vertical line from branch_y to top of to_node for each target
-        // For T-junction, we need to draw vertical lines to both left and right nodes
-        let vertical_start_y = branch_y + 1;
-        let vertical_end_y = to_top_y.min(area.height);
+    // 2. Branch row, composed cell-by-cell so junctions render correctly.
+    let mut glyphs = String::new();
+    for c in left..=right {
+        let up = c == parent_center_x;
+        let down = children.iter().any(|&(cx, _)| cx == c);
+        let lft = c > left;
+        let rgt = c < right;
+        glyphs.push(box_glyph(up, down, lft, rgt));
+    }
+    draw_hline(f, area, left, branch_y, &glyphs, color);
 
-        if vertical_start_y < vertical_end_y && to_center_x < area.width {
-            let vertical_height = vertical_end_y.saturating_sub(vertical_start_y);
-            if vertical_height > 0 {
-                let vertical_area = Rect {
-                    x: area.x + to_center_x,
-                    y: area.y + vertical_start_y,
-                    width: 1,
-                    height: vertical_height,
-                };
-                let mut lines = Vec::new();
-                for _ in 0..vertical_area.height {
-                    lines.push(Line::from("│"));
-                }
-                let paragraph = Paragraph::new(lines).style(Style::default().fg(edge_color));
-                f.render_widget(paragraph, vertical_area);
-            }
-        }
-    } else {
-        // Nodes are vertically aligned: draw straight vertical line
-        let start_y = from_bottom_y;
-        let end_y = to_top_y;
-
-        // Only draw if there's space between nodes
-        if start_y < end_y && start_y < area.height && end_y > 0 {
-            let line_x = from_center_x;
-
-            if line_x < area.width {
-                let line_height = end_y.saturating_sub(start_y);
-
-                // Skip if no space (nodes are directly adjacent)
-                if line_height > 0 {
-                    let edge_area = Rect {
-                        x: area.x + line_x,
-                        y: area.y + start_y,
-                        width: 1,
-                        height: line_height.min(area.height.saturating_sub(start_y)),
-                    };
-
-                    // Create vertical line with repeated │ characters
-                    let mut lines = Vec::new();
-                    for _ in 0..edge_area.height {
-                        lines.push(Line::from("│"));
-                    }
-
-                    let paragraph = Paragraph::new(lines).style(Style::default().fg(edge_color));
-                    f.render_widget(paragraph, edge_area);
-                }
-            }
+    // 3. Short drop from the branch into each child top (zero-length when the
+    //    child sits directly below the branch row).
+    let drop_start = branch_y + 1;
+    for &(cx, top) in children {
+        if top > drop_start {
+            draw_vline(f, area, cx, drop_start, top - drop_start, color);
         }
     }
 }
@@ -609,6 +366,7 @@ fn render_node_text(
     y: u16,
     node: &crate::trace::GraphNode,
     scroll_offset: u16, // Line-based scroll offset
+    is_focused: bool,   // Whether this node has keyboard focus
     theme: &Theme,
 ) {
     // Adjust Y position for scroll offset (like YAML view)
@@ -895,12 +653,29 @@ fn render_node_text(
         }
     }
 
-    // Create the outer block with borders
-    // Use Reset background to ensure transparent background (matches terminal default)
-    let block = Block::default()
+    // Create the outer block with borders.
+    // Use Reset background to ensure transparent background (matches terminal default).
+    // The focused node gets a bright, bold double border in the accent color
+    // (distinct from the status/text colors every other border uses) plus a "▸"
+    // title marker, so the selection is unmistakable at a glance.
+    let focus_style = Style::default()
+        .fg(theme.footer_key)
+        .add_modifier(Modifier::BOLD);
+
+    let mut block = Block::default()
         .borders(Borders::ALL)
-        .border_style(border_style)
+        .border_style(if is_focused {
+            focus_style
+        } else {
+            border_style
+        })
         .style(Style::default().bg(ratatui::style::Color::Reset));
+
+    if is_focused {
+        block = block
+            .border_type(ratatui::widgets::BorderType::Double)
+            .title(Span::styled(" ▸ ", focus_style));
+    }
 
     // Render the outer block
     f.render_widget(block, node_area);
@@ -1005,15 +780,16 @@ fn render_node_text(
         );
     }
 
-    // Render name (bold)
-    f.render_widget(
-        Paragraph::new(vec![name_line]).style(
-            title_style
-                .add_modifier(Modifier::BOLD)
-                .bg(ratatui::style::Color::Reset),
-        ),
-        name_area,
-    );
+    // Render name (bold). The focused node's name takes the accent color too,
+    // reinforcing the highlighted border.
+    let name_style = if is_focused {
+        focus_style.bg(ratatui::style::Color::Reset)
+    } else {
+        title_style
+            .add_modifier(Modifier::BOLD)
+            .bg(ratatui::style::Color::Reset)
+    };
+    f.render_widget(Paragraph::new(vec![name_line]).style(name_style), name_area);
 
     // Render horizontal separator line below name
     let separator = "─".repeat(inner.width as usize);
@@ -1053,5 +829,88 @@ fn render_node_text(
                 .wrap(ratatui::widgets::Wrap { trim: true });
             f.render_widget(paragraph, clipped_content_area);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{box_glyph, fanout_routes};
+    use crate::trace::{GraphEdge, GraphNode, NodeType, RelationshipType, ResourceGraph};
+
+    #[test]
+    fn box_glyph_renders_expected_junctions() {
+        // up, down, left, right
+        assert_eq!(box_glyph(true, true, true, true), '┼'); // cross
+        assert_eq!(box_glyph(false, true, true, true), '┬'); // child drop on the branch
+        assert_eq!(box_glyph(true, false, true, true), '┴'); // trunk meets the branch
+        assert_eq!(box_glyph(false, true, false, true), '┌'); // left end with a drop
+        assert_eq!(box_glyph(false, true, true, false), '┐'); // right end with a drop
+        assert_eq!(box_glyph(true, false, false, true), '└'); // left end, trunk above
+        assert_eq!(box_glyph(true, false, true, false), '┘'); // right end, trunk above
+        assert_eq!(box_glyph(false, false, true, true), '─'); // plain horizontal
+        assert_eq!(box_glyph(true, true, false, false), '│'); // plain vertical (aligned child)
+    }
+
+    fn node(id: &str, node_type: NodeType, desc: Option<&str>) -> GraphNode {
+        GraphNode {
+            id: id.to_string(),
+            kind: "Kind".to_string(),
+            name: id.to_string(),
+            namespace: "ns".to_string(),
+            node_type,
+            ready: None,
+            position: None,
+            description: desc.map(|d| d.to_string()),
+        }
+    }
+
+    #[test]
+    fn fanout_routes_connects_object_to_its_inventory_groups() {
+        let mut graph = ResourceGraph::new();
+        graph.add_node(node("obj", NodeType::Object, None));
+        graph.add_node(node(
+            "wg",
+            NodeType::WorkloadGroup,
+            Some("Deployment|a|ns|●|1/1"),
+        ));
+        graph.add_node(node("rg", NodeType::ResourceGroup, Some("ConfigMap: 1")));
+        for child in ["wg", "rg"] {
+            graph.add_edge(GraphEdge {
+                from: "obj".to_string(),
+                to: child.to_string(),
+                relationship: RelationshipType::Owns,
+            });
+        }
+
+        graph.calculate_layout(100, 50);
+        let routes = fanout_routes(&graph, 100, 0);
+
+        // One parent (the object) with both inventory groups as children.
+        assert_eq!(routes.len(), 1);
+        let route = &routes[0];
+        assert_eq!(route.relationship, RelationshipType::Owns);
+        assert_eq!(route.children.len(), 2);
+
+        // Children sit below the parent's bottom edge.
+        assert!(
+            route
+                .children
+                .iter()
+                .all(|&(_, top)| top > route.parent_bottom_y)
+        );
+
+        // The trunk falls between the child centers (a centered fan-out).
+        let min_x = route.children.iter().map(|&(x, _)| x).min().unwrap();
+        let max_x = route.children.iter().map(|&(x, _)| x).max().unwrap();
+        assert!(min_x <= route.parent_center_x && route.parent_center_x <= max_x);
+    }
+
+    #[test]
+    fn fanout_routes_skips_parents_without_placed_children() {
+        // A lone node with no edges produces no routes.
+        let mut graph = ResourceGraph::new();
+        graph.add_node(node("solo", NodeType::Object, None));
+        graph.calculate_layout(100, 50);
+        assert!(fanout_routes(&graph, 100, 0).is_empty());
     }
 }

--- a/src/tui/views/help.rs
+++ b/src/tui/views/help.rs
@@ -65,7 +65,7 @@ pub fn render_help(f: &mut Frame, area: Rect, theme: &Theme, namespace_hotkeys: 
         ("<k>/<Up>", "Navigate up"),
         ("<Ctrl+f>/<PgDn>", "Page down"),
         ("<Ctrl+b>/<PgUp>", "Page up"),
-        ("<Enter>", "View details"),
+        ("<Enter>", "Open details / focused graph node"),
         ("<N>/<A>/<T>/<S>", "Sort name/age/type/status"),
         ("</>", "Search in YAML/describe/trace"),
         ("<n>/<N>", "Next/prev search match"),


### PR DESCRIPTION
Signed-off-by: Daniel Guns <danbguns@gmail.com>

### Highlights
  - **Keyboard navigation** — `j`/`k` move a highlighted focus between nodes (the view auto-scrolls to keep it visible), `Enter` opens the
  focused resource's detail view, and `Esc` returns to the graph. Focus starts on the resource you opened the graph from.
  - **Clearer connectors** — edges are redrawn as consistent fan-outs (trunk → branch above the children → drop into each child) with proper
  box-drawing junctions, and nodes sit closer together. Fixes the ambiguous full-height "rails" the old routing produced.
  - **Brighter focus highlight** — the selected node gets a bold accent border and marker.

  ### Internal / maintainability
  - Single source of truth for graph node sizing (`GraphNode::render_width`/`render_height`); connector geometry extracted into the pure,
  `Frame`-free `fanout_routes()` so it's unit-testable.
  - Per-view behavior consolidated onto `impl View` helpers instead of scattered `match` arms.
  - `:` command handling is now data-driven via a `COMMAND_TABLE` of `(predicate, handler)` pairs, replacing the long string-matching chain in
  `execute_command`.