### PR TITLE
Events, async watch rework, bug fixes, enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Kubernetes Events support:
+  - The describe view (`d`) now ends with a kubectl-style Events section
+    showing the resource's recent events (Warnings highlighted; degrades to a
+    notice when events are unavailable, e.g. RBAC).
+  - New `:events` (alias `:ev`) live events feed for the current namespace
+    scope — cluster-wide with `:ns all`. Streams in real time, newest first,
+    filterable with `/`; `Enter` jumps to the involved Flux resource. The
+    events watcher runs only while the view is open.
+- Resource action keys now resolve their target from any view via a single
+  `view_target()` resolver: `y`/`d` (and `t`/`g`/`h`/operations for watched
+  resources) act on the selected event's involved object in the events feed
+  and on the focused node in the graph view — previously these keys only
+  worked from the resource list, favorites, and detail views. `y`/`d` work
+  for non-Flux objects too (Pods, Deployments, …) via the API fetch path,
+  and Back returns to the view you came from (events feed or graph).
 - Graph view keyboard navigation: `j`/`k` move a highlighted focus between nodes
   (the view auto-scrolls to keep it visible), `Enter` opens the focused resource's
   detail view, and `Esc` returns to the graph.
@@ -17,7 +32,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   children → drop into each child) using proper box-drawing junctions, and nodes
   sit closer together for a tighter, clearer layout.
 
+### Fixed
+- `:all` now returns to the main resource list from the events feed (and stops
+  the events watch), instead of only clearing filters while stuck in the view.
+- The events feed's "not a watched Flux resource" message now names the
+  involved object's namespace and points at `y`/`d`, so namespace-scope
+  mismatches are visible instead of just confusing.
+
 ### Internal
+- New generic `AsyncTask<K, T>` owns the request/dispatch/poll lifecycle for
+  view fetches, replacing the five copy-pasted `*_pending`/`*_fetched`/`*_rx`
+  field triplets and their hand-rolled trigger/poll methods.
+- YAML/describe fetch requests are now typed `ResourceKey`s instead of
+  `"type:namespace:name"` strings, removing the re-parse (and its can't-happen
+  error branches) from the main loop.
+- The Kubernetes events watcher has an independent lifecycle from the resource
+  watchers (started lazily, stopped without a full watcher teardown), and
+  survives namespace switches.
 - Single source of truth for graph node sizing (`GraphNode::render_width`/
   `render_height`); connector geometry extracted into the testable, `Frame`-free
   `fanout_routes()`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -106,10 +106,15 @@ Terminal user interface built with ratatui.
 
 - **`app/`** - Application state and logic (refactored from single file):
   - `core.rs` - Main App struct and core logic
-  - `state.rs` - State structures (ViewState, SelectionState, UIState, AsyncOperationState)
+  - `state.rs` - State structures (ViewState, SelectionState, UIState, AsyncOperationState, KubeEventStore)
   - `events.rs` - Event handling and input processing
   - `rendering.rs` - Rendering orchestration
-  - `async_ops.rs` - Async operation management
+  - `async_task.rs` - Generic `AsyncTask<K, T>`: one type owns the
+    request → dispatch → poll lifecycle for every view fetch (YAML, describe,
+    trace, graph). Event handlers call `request()`, the main loop calls
+    `dispatch()` and spawns the work, then polls `try_recv()` each tick.
+  - `async_ops.rs` - Mutating-operation flow (registry validation, status
+    message bookkeeping) and the graph result hook
 - **`operations.rs`** - Flux operations (suspend, resume, delete, reconcile, reconcile with source)
 - **`theme.rs`** - Theme configuration and loading
 - **`trace.rs`** - Trace operation orchestration
@@ -127,6 +132,7 @@ Terminal user interface built with ratatui.
   - `trace.rs` - Trace view showing resource ownership chains
   - `graph.rs` - Graph visualization view
   - `history.rs` - Reconciliation history view
+  - `events.rs` - Live Kubernetes events feed (`:events`)
   - `confirmation.rs` - Confirmation dialogs
   - `help.rs` - Help screen
   - `splash.rs` - Splash screen
@@ -139,6 +145,10 @@ Terminal user interface built with ratatui.
 - Non-blocking async operations using `tokio::spawn`
 - Modular app structure with separated concerns (state, events, rendering, async)
 - Separate scroll offsets for different views
+- The Kubernetes events watcher (`ResourceWatcher::watch_kube_events`) has an
+  independent lifecycle from the resource watchers: started lazily when the
+  events view opens, stopped (and its `KubeEventStore` feed cleared) when the
+  view is left, and restarted automatically across namespace/context switches
 - Per-view behavior (scroll target, back navigation, classification) lives on
   `impl View` (`src/tui/app/state.rs`) rather than scattered `match` arms
 - Dynamic footer wrapping for smaller screens

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A [K9s](https://github.com/derailed/k9s)-inspired terminal UI for monitoring Flu
 - **Unified and type-specific views** - View all resources together or filter by type
 - **Resource operations** - Suspend, resume, reconcile, and delete Flux resources
 - **YAML viewing** - Inspect full resource manifests
+- **Kubernetes Events** - Per-resource events in the describe view, plus a live `:events` feed for the current namespace or cluster
 - **Graph visualization** - Visualize resource relationships and dependencies (Kustomization, HelmRelease, etc.)
 - **Reconciliation history** - View reconciliation history for resources that track it
 - **Favorites** - Mark frequently accessed resources for quick access
@@ -143,6 +144,7 @@ By default, `flux9s` watches the `flux-system` namespace. Use `:ns all` to view 
 - `:ns <namespace>` - Switch namespace
 - `:ns all` - View all namespaces
 - `:favorites` or `:fav` - View favorite resources
+- `:events` or `:ev` - Live Kubernetes events feed (current namespace scope)
 - `:skin {skin-name}` - set skin directly
 - `:skin` - open interactive theme selection menu with live preview (17 built-in themes + custom)
 - `:q` or `:q!` - Quit
@@ -152,6 +154,7 @@ By default, `flux9s` watches the `flux-system` namespace. Use `:ns all` to view 
 
 - **Graph View (`g`)** - Visualize resource relationships and dependencies. Shows upstream sources and downstream managed resources. Move the highlighted focus between nodes with `j`/`k` (the view scrolls to keep it visible), press `Enter` to open the focused resource's detail view, and `Esc` to return to the graph. Supported for Kustomization, HelmRelease, ArtifactGenerator, FluxInstance, and ResourceSet.
 - **History View (`h`)** - View reconciliation history for FluxInstance, ResourceSet, Kustomization, and HelmRelease resources.
+- **Events View (`:events`)** - Live Kubernetes events feed for the current namespace (or cluster-wide with `:ns all`), newest first with Warnings highlighted. `Enter` jumps to the involved resource; the describe view (`d`) also shows a per-resource Events section.
 - **Favorites (`f`)** - Mark resources as favorites for quick access. Use `:favorites` command to view all favorites.
 
 ### Terminal Commands

--- a/docs/content/user-guide/_index.md
+++ b/docs/content/user-guide/_index.md
@@ -95,6 +95,8 @@ Type these commands in command mode (press `:`):
 | `:unhealthy`       | Show only unhealthy resources            |
 | `:favorites`       | View favorite resources                  |
 | `:fav`             | Alias for `:favorites`                   |
+| `:events`          | Live Kubernetes events feed              |
+| `:ev`              | Alias for `:events`                      |
 | `:skin <name>`     | Change theme/skin (direct)               |
 | `:skin`            | Open interactive theme selection menu    |
 | `:readonly`        | Toggle readonly mode                     |
@@ -219,7 +221,8 @@ The graph view displays:
 
 - `j` / `k` (or `↓` / `↑`) - Move the highlighted focus between nodes; the view scrolls to keep the focused node visible.
 - `Enter` - Open the focused node's resource in the detail view. Aggregate nodes (workload/resource groups) and external upstream URLs aren't directly openable.
-- `Esc` / `Backspace` - Return to the graph (when you opened a detail view from it), then back to the resource list.
+- `y` / `d` - View the focused node's YAML or describe output directly, including managed workloads (Deployments, Services, etc.).
+- `Esc` / `Backspace` - Return to the graph (when you opened a view from it), then back to the resource list.
 
 Focus starts on the resource you opened the graph from, so you can immediately walk its sources and dependencies.
 
@@ -249,6 +252,31 @@ Mark frequently accessed resources as favorites for quick access.
 - Use `:favorites` or `:fav` command to view all favorites
 - Favorites are saved to your configuration file
 - Favorites appear first in resource lists
+
+### Events View (`:events`)
+
+A live feed of Kubernetes Events in the current namespace scope — the
+"what is Flux doing right now" view. Flux controllers emit an Event for every
+reconciliation success and failure, so this surfaces error detail that the
+resource list's MESSAGE column truncates.
+
+- The feed follows your namespace scope: the current namespace by default, or
+  the whole cluster after `:ns all` (a NAMESPACE column appears)
+- Events are streamed in real time, newest first, with Warnings highlighted
+- `/` filters by type, reason, object, namespace, source, or message text
+- `Enter` on an event jumps to the involved resource's detail view when it is
+  a Flux resource flux9s watches; `Esc` returns to the events feed
+- Resource keys act on the selected event's involved object directly: `y`
+  (YAML) and `d` (describe) work even for non-Flux objects like Pods and
+  Deployments, while `t`/`g`/`h` and operations (`s`/`r`/`R`) work when the
+  object is a watched Flux resource. `Esc` from any of these returns to the
+  events feed
+- `Esc` from the feed returns to the resource list and stops the events watch —
+  events are only streamed while the view is open, so there is no overhead the
+  rest of the time
+
+Events also appear in the describe view (`d`): each resource's describe output
+ends with a kubectl-style Events section listing that resource's recent events.
 
 ## Operations
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -9,6 +9,11 @@ pub const RESOURCE_KEY_FORMAT: &str = "resource_type:namespace:name";
 /// Maximum number of reconciliation history events to store per resource
 pub const MAX_RECONCILIATION_HISTORY: usize = 50;
 
+/// Cap on the live Kubernetes events feed. Events are the churniest resource
+/// in a cluster; the store evicts oldest-seen entries past this bound so a
+/// busy cluster can't grow memory without limit.
+pub const MAX_KUBE_EVENTS: usize = 1000;
+
 /// Status message timeout in seconds
 pub const STATUS_MESSAGE_TIMEOUT_SECS: u64 = 4;
 

--- a/src/kube/events.rs
+++ b/src/kube/events.rs
@@ -1,0 +1,225 @@
+//! Kubernetes Events (core/v1) support.
+//!
+//! One shared model backs both event surfaces: the live events view (fed by
+//! the watcher) and the Events section of the describe view (fetched on
+//! demand for one resource). Flux controllers emit these events through the
+//! standard event recorder, so they carry the reconciliation error detail
+//! that `status.conditions` truncates.
+
+use anyhow::Context;
+use k8s_openapi::api::core::v1::Event as CoreEvent;
+use kube::Api;
+use kube::api::ListParams;
+
+/// A Kubernetes Event reduced to the fields flux9s displays.
+#[derive(Debug, Clone)]
+pub struct KubeEventInfo {
+    /// Object UID — the dedup key for the live event store.
+    pub uid: String,
+    /// "Normal" or "Warning".
+    pub event_type: String,
+    /// Machine-readable reason (e.g. "ReconciliationSucceeded").
+    pub reason: String,
+    /// Human-readable message.
+    pub message: String,
+    /// Kind of the object this event is about.
+    pub involved_kind: String,
+    /// Namespace of the involved object (falls back to the event's namespace).
+    pub involved_namespace: String,
+    /// Name of the involved object.
+    pub involved_name: String,
+    /// Number of occurrences (deduplicated events aggregate here).
+    pub count: i64,
+    /// Most recent occurrence.
+    pub last_seen: Option<chrono::DateTime<chrono::Utc>>,
+    /// Reporting component (e.g. "kustomize-controller").
+    pub source: String,
+}
+
+impl KubeEventInfo {
+    /// Whether this is a Warning event (drives error styling).
+    pub fn is_warning(&self) -> bool {
+        self.event_type == "Warning"
+    }
+
+    /// `Kind/name` label for the OBJECT column.
+    pub fn object_label(&self) -> String {
+        format!("{}/{}", self.involved_kind, self.involved_name)
+    }
+
+    /// Parse from a core/v1 Event JSON object.
+    ///
+    /// Returns `None` when the UID is missing (never the case for real API
+    /// objects). Absent display fields degrade to empty strings so a sparse
+    /// event still renders.
+    pub fn from_json(event_json: &serde_json::Value) -> Option<Self> {
+        let uid = event_json["metadata"]["uid"].as_str()?.to_string();
+        let str_field = |value: &serde_json::Value| value.as_str().unwrap_or_default().to_string();
+
+        let involved = &event_json["involvedObject"];
+        let involved_namespace = involved["namespace"]
+            .as_str()
+            .or(event_json["metadata"]["namespace"].as_str())
+            .unwrap_or_default()
+            .to_string();
+
+        // Events created through the newer events.k8s.io API and mirrored into
+        // core/v1 carry their occurrence data in different fields.
+        let last_seen = ["lastTimestamp", "eventTime"]
+            .iter()
+            .map(|field| &event_json[field])
+            .chain([
+                &event_json["series"]["lastObservedTime"],
+                &event_json["metadata"]["creationTimestamp"],
+            ])
+            .find_map(|value| {
+                value
+                    .as_str()
+                    .and_then(|ts| ts.parse::<chrono::DateTime<chrono::Utc>>().ok())
+            });
+        let count = event_json["count"]
+            .as_i64()
+            .or(event_json["series"]["count"].as_i64())
+            .unwrap_or(1);
+        let source = event_json["source"]["component"]
+            .as_str()
+            .or(event_json["reportingComponent"].as_str())
+            .unwrap_or_default()
+            .to_string();
+
+        Some(Self {
+            uid,
+            event_type: str_field(&event_json["type"]),
+            reason: str_field(&event_json["reason"]),
+            message: str_field(&event_json["message"]),
+            involved_kind: str_field(&involved["kind"]),
+            involved_namespace,
+            involved_name: str_field(&involved["name"]),
+            count,
+            last_seen,
+            source,
+        })
+    }
+}
+
+/// Fetch the Events for one resource, newest first — the same query
+/// `kubectl describe` runs. Returns an empty list when the resource has no
+/// events; errors (e.g. RBAC) are surfaced so the caller can degrade.
+pub async fn fetch_events_for_resource(
+    client: &kube::Client,
+    kind: &str,
+    namespace: &str,
+    name: &str,
+) -> anyhow::Result<Vec<KubeEventInfo>> {
+    let api: Api<CoreEvent> = Api::namespaced(client.clone(), namespace);
+    let field_selector = format!(
+        "involvedObject.kind={},involvedObject.name={},involvedObject.namespace={}",
+        kind, name, namespace
+    );
+    let params = ListParams::default().fields(&field_selector);
+    let events = api.list(&params).await.with_context(|| {
+        format!(
+            "Failed to list events for {}/{} in namespace {}",
+            kind, name, namespace
+        )
+    })?;
+
+    let mut infos: Vec<KubeEventInfo> = events
+        .items
+        .iter()
+        .filter_map(|event| {
+            serde_json::to_value(event)
+                .ok()
+                .as_ref()
+                .and_then(KubeEventInfo::from_json)
+        })
+        .collect();
+    infos.sort_by_key(|info| std::cmp::Reverse(info.last_seen));
+    Ok(infos)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_event() -> serde_json::Value {
+        serde_json::json!({
+            "metadata": {
+                "name": "podinfo.17c1e8a",
+                "namespace": "flux-system",
+                "uid": "aaaa-bbbb",
+                "creationTimestamp": "2026-07-01T10:00:00Z"
+            },
+            "involvedObject": {
+                "kind": "Kustomization",
+                "namespace": "flux-system",
+                "name": "podinfo"
+            },
+            "type": "Warning",
+            "reason": "ReconciliationFailed",
+            "message": "kustomization path not found",
+            "count": 4,
+            "lastTimestamp": "2026-07-01T12:30:00Z",
+            "source": {"component": "kustomize-controller"}
+        })
+    }
+
+    #[test]
+    fn parses_core_v1_event() {
+        let info = KubeEventInfo::from_json(&sample_event()).expect("event should parse");
+        assert_eq!(info.uid, "aaaa-bbbb");
+        assert!(info.is_warning());
+        assert_eq!(info.reason, "ReconciliationFailed");
+        assert_eq!(info.object_label(), "Kustomization/podinfo");
+        assert_eq!(info.involved_namespace, "flux-system");
+        assert_eq!(info.count, 4);
+        assert_eq!(info.source, "kustomize-controller");
+        assert_eq!(
+            info.last_seen.unwrap().to_rfc3339(),
+            "2026-07-01T12:30:00+00:00"
+        );
+    }
+
+    #[test]
+    fn parses_events_k8s_io_style_fields() {
+        // Events mirrored from events.k8s.io/v1: no lastTimestamp/count,
+        // occurrence data lives in eventTime/series, source in reportingComponent.
+        let event = serde_json::json!({
+            "metadata": {"uid": "cccc", "namespace": "default"},
+            "involvedObject": {"kind": "HelmRelease", "name": "podinfo"},
+            "type": "Normal",
+            "reason": "UpgradeSucceeded",
+            "message": "Helm upgrade succeeded",
+            "eventTime": "2026-07-02T08:00:00.000000Z",
+            "series": {"count": 7, "lastObservedTime": "2026-07-02T09:00:00.000000Z"},
+            "reportingComponent": "helm-controller"
+        });
+        let info = KubeEventInfo::from_json(&event).expect("event should parse");
+        assert!(!info.is_warning());
+        assert_eq!(info.count, 7);
+        assert_eq!(info.source, "helm-controller");
+        // eventTime is preferred over series.lastObservedTime
+        assert_eq!(
+            info.last_seen.unwrap().to_rfc3339(),
+            "2026-07-02T08:00:00+00:00"
+        );
+        // involvedObject.namespace falls back to the event's namespace
+        assert_eq!(info.involved_namespace, "default");
+    }
+
+    #[test]
+    fn missing_uid_returns_none() {
+        assert!(KubeEventInfo::from_json(&serde_json::json!({"metadata": {}})).is_none());
+    }
+
+    #[test]
+    fn sparse_event_degrades_to_empty_fields() {
+        let info = KubeEventInfo::from_json(&serde_json::json!({
+            "metadata": {"uid": "dddd"}
+        }))
+        .expect("uid alone is enough");
+        assert_eq!(info.event_type, "");
+        assert_eq!(info.count, 1);
+        assert!(info.last_seen.is_none());
+    }
+}

--- a/src/kube/fetch.rs
+++ b/src/kube/fetch.rs
@@ -45,3 +45,54 @@ pub async fn fetch_resource_yaml(
 ) -> anyhow::Result<serde_json::Value> {
     fetch_resource(client, resource_type, namespace, name).await
 }
+
+/// Payload backing the describe view: the full object plus its Kubernetes
+/// Events, fetched together so the view renders in one pass.
+#[derive(Debug, Clone)]
+pub struct DescribeData {
+    /// The full resource object.
+    pub object: serde_json::Value,
+    /// The resource's events, newest first.
+    pub events: Vec<crate::kube::events::KubeEventInfo>,
+    /// Set when the events lookup failed (e.g. RBAC) — the describe view
+    /// degrades to a notice instead of failing entirely.
+    pub events_error: Option<String>,
+}
+
+/// Fetch a resource and its Events for the describe view.
+///
+/// The object fetch failing fails the describe; the events fetch failing
+/// only degrades the Events section.
+pub async fn fetch_describe_data(
+    client: &kube::Client,
+    resource_type: &str,
+    namespace: &str,
+    name: &str,
+) -> anyhow::Result<DescribeData> {
+    let object = fetch_resource(client, resource_type, namespace, name).await?;
+    let (events, events_error) = match crate::kube::events::fetch_events_for_resource(
+        client,
+        resource_type,
+        namespace,
+        name,
+    )
+    .await
+    {
+        Ok(events) => (events, None),
+        Err(e) => {
+            tracing::warn!(
+                "Events lookup failed for {}/{} in namespace {}: {}",
+                resource_type,
+                name,
+                namespace,
+                e
+            );
+            (Vec::new(), Some(format!("{}", e)))
+        }
+    };
+    Ok(DescribeData {
+        object,
+        events,
+        events_error,
+    })
+}

--- a/src/kube/mod.rs
+++ b/src/kube/mod.rs
@@ -12,6 +12,7 @@
 //! to prevent proxy issues with corporate environments.
 
 pub mod api;
+pub mod events;
 pub mod fetch;
 pub mod health;
 pub mod inventory;

--- a/src/services/cluster_session.rs
+++ b/src/services/cluster_session.rs
@@ -327,7 +327,9 @@ impl ClusterSession {
             }
             WatchEvent::PodApplied(_, _)
             | WatchEvent::PodDeleted(_)
-            | WatchEvent::DeploymentApplied(_) => {}
+            | WatchEvent::DeploymentApplied(_)
+            | WatchEvent::KubeEventApplied(_)
+            | WatchEvent::KubeEventDeleted(_) => {}
         }
     }
 

--- a/src/tui/app/async_ops.rs
+++ b/src/tui/app/async_ops.rs
@@ -1,24 +1,13 @@
 //! Async operation management
 //!
-//! This module handles all asynchronous operations including YAML fetching,
-//! tracing, graph building, and resource operations with their result channels.
+//! The per-view fetches (YAML, describe, trace, graph) are plain
+//! [`AsyncTask`](crate::tui::app::async_task::AsyncTask) slots on
+//! [`AsyncOperationState`](super::state::AsyncOperationState); the main loop
+//! dispatches and polls them directly. This module keeps only the flows with
+//! extra semantics: mutating operations (registry validation, success message
+//! bookkeeping) and the graph result hook (initial keyboard focus).
 
 use super::core::App;
-use crate::watcher::ResourceKey;
-
-/// Request to trace a resource's ownership chain
-pub struct TraceRequest {
-    /// The type of resource to trace (e.g., "Kustomization", "HelmRelease")
-    pub resource_type: String,
-    /// The namespace of the resource
-    pub namespace: String,
-    /// The name of the resource
-    pub name: String,
-    /// Kubernetes client to use for API calls
-    pub client: kube::Client,
-    /// Channel to send the trace result back
-    pub tx: tokio::sync::oneshot::Sender<anyhow::Result<crate::tui::trace::TraceResult>>,
-}
 
 /// Request to execute an operation on a resource
 pub struct OperationRequest {
@@ -37,290 +26,50 @@ pub struct OperationRequest {
 }
 
 impl App {
-    /// Trigger YAML fetch if pending
-    ///
-    /// Returns (resource_key, client, result_channel) if fetch should be triggered
-    pub fn trigger_yaml_fetch(
-        &mut self,
-    ) -> Option<(
-        String,
-        kube::Client,
-        tokio::sync::oneshot::Sender<anyhow::Result<serde_json::Value>>,
-    )> {
-        if let Some(ref key) = self.async_state.yaml_fetch_pending {
-            if let Some(ref client) = self.kube_client {
-                let (tx, rx) = tokio::sync::oneshot::channel();
-                let key_clone = key.clone();
-                let client_clone = client.clone();
-                self.async_state.yaml_fetch_pending = None;
-                self.async_state.yaml_fetch_rx = Some(rx);
-                return Some((key_clone, client_clone, tx));
-            }
-        }
-        None
-    }
-
-    /// Trigger describe fetch if pending
-    pub fn trigger_describe_fetch(
-        &mut self,
-    ) -> Option<(
-        String,
-        kube::Client,
-        tokio::sync::oneshot::Sender<anyhow::Result<serde_json::Value>>,
-    )> {
-        if let Some(ref key) = self.async_state.describe_fetch_pending {
-            if let Some(ref client) = self.kube_client {
-                let (tx, rx) = tokio::sync::oneshot::channel();
-                let key_clone = key.clone();
-                let client_clone = client.clone();
-                self.async_state.describe_fetch_pending = None;
-                self.async_state.describe_fetch_rx = Some(rx);
-                return Some((key_clone, client_clone, tx));
-            }
-        }
-        None
-    }
-
-    /// Set YAML fetch result
-    pub fn set_yaml_fetched(&mut self, yaml: serde_json::Value) {
-        self.async_state.yaml_fetched = Some(yaml);
-    }
-
-    /// Set YAML fetch error
-    pub fn set_yaml_fetch_error(&mut self) {
-        self.async_state.yaml_fetched = None;
-        self.async_state.yaml_fetch_pending = None;
-    }
-
-    /// Set describe fetch result
-    pub fn set_describe_fetched(&mut self, describe: serde_json::Value) {
-        self.async_state.describe_fetched = Some(describe);
-    }
-
-    /// Set describe fetch error
-    pub fn set_describe_fetch_error(&mut self) {
-        self.async_state.describe_fetched = None;
-        self.async_state.describe_fetch_pending = None;
-    }
-
-    /// Try to get YAML fetch result
-    pub fn try_get_yaml_result(&mut self) -> Option<anyhow::Result<serde_json::Value>> {
-        if let Some(ref mut rx) = self.async_state.yaml_fetch_rx {
-            match rx.try_recv() {
-                Ok(result) => {
-                    self.async_state.yaml_fetch_rx = None;
-                    return Some(result);
-                }
-                Err(tokio::sync::oneshot::error::TryRecvError::Empty) => {
-                    return None;
-                }
-                Err(_) => {
-                    self.async_state.yaml_fetch_rx = None;
-                    return Some(Err(anyhow::anyhow!("YAML fetch failed")));
-                }
-            }
-        }
-        None
-    }
-
-    /// Try to get describe fetch result
-    pub fn try_get_describe_result(&mut self) -> Option<anyhow::Result<serde_json::Value>> {
-        if let Some(ref mut rx) = self.async_state.describe_fetch_rx {
-            match rx.try_recv() {
-                Ok(result) => {
-                    self.async_state.describe_fetch_rx = None;
-                    return Some(result);
-                }
-                Err(tokio::sync::oneshot::error::TryRecvError::Empty) => {
-                    return None;
-                }
-                Err(_) => {
-                    self.async_state.describe_fetch_rx = None;
-                    return Some(Err(anyhow::anyhow!("Describe fetch failed")));
-                }
-            }
-        }
-        None
-    }
-
-    /// Trigger trace if pending
-    pub fn trigger_trace(&mut self) -> Option<TraceRequest> {
-        if let Some(ref rk) = self.async_state.trace_pending {
-            if let Some(ref client) = self.kube_client {
-                let (tx, rx) = tokio::sync::oneshot::channel();
-                let request = TraceRequest {
-                    resource_type: rk.resource_type.clone(),
-                    namespace: rk.namespace.clone(),
-                    name: rk.name.clone(),
-                    client: client.clone(),
-                    tx,
-                };
-                self.async_state.trace_pending = None;
-                self.async_state.trace_result_rx = Some(rx);
-                return Some(request);
-            }
-        }
-        None
-    }
-
-    /// Set trace result
-    pub fn set_trace_result(&mut self, result: crate::tui::trace::TraceResult) {
-        self.async_state.trace_result = Some(result);
-    }
-
-    /// Set trace error
-    pub fn set_trace_error(&mut self) {
-        self.async_state.trace_result = None;
-        self.async_state.trace_pending = None;
-    }
-
-    /// Try to get trace result
-    pub fn try_get_trace_result(
-        &mut self,
-    ) -> Option<anyhow::Result<crate::tui::trace::TraceResult>> {
-        if let Some(ref mut rx) = self.async_state.trace_result_rx {
-            match rx.try_recv() {
-                Ok(result) => {
-                    self.async_state.trace_result_rx = None;
-                    return Some(result);
-                }
-                Err(tokio::sync::oneshot::error::TryRecvError::Empty) => {
-                    return None;
-                }
-                Err(_) => {
-                    self.async_state.trace_result_rx = None;
-                    return Some(Err(anyhow::anyhow!("Trace failed")));
-                }
-            }
-        }
-        None
-    }
-
-    /// Trigger graph building if pending
-    pub fn trigger_graph(
-        &mut self,
-    ) -> Option<(
-        ResourceKey,
-        kube::Client,
-        tokio::sync::oneshot::Sender<anyhow::Result<crate::trace::ResourceGraph>>,
-    )> {
-        if let Some(ref rk) = self.async_state.graph_pending {
-            if let Some(ref client) = self.kube_client {
-                let (tx, rx) = tokio::sync::oneshot::channel();
-                let request = (rk.clone(), client.clone(), tx);
-                self.async_state.graph_pending = None;
-                self.async_state.graph_result_rx = Some(rx);
-                return Some(request);
-            }
-        }
-        None
-    }
-
-    /// Try to get graph result
-    pub fn try_get_graph_result(&mut self) -> Option<anyhow::Result<crate::trace::ResourceGraph>> {
-        if let Some(ref mut rx) = self.async_state.graph_result_rx {
-            match rx.try_recv() {
-                Ok(result) => {
-                    self.async_state.graph_result_rx = None;
-                    return Some(result);
-                }
-                Err(tokio::sync::oneshot::error::TryRecvError::Empty) => {
-                    return None;
-                }
-                Err(_) => {
-                    self.async_state.graph_result_rx = None;
-                    return Some(Err(anyhow::anyhow!("Graph building failed")));
-                }
-            }
-        }
-        None
-    }
-
-    /// Set graph result
-    pub fn set_graph_result(&mut self, result: crate::trace::ResourceGraph) {
-        // Start keyboard focus on the resource being viewed (the object node) so
-        // the graph is immediately navigable with j/k and Enter.
-        self.view_state.graph_focus_index = result.object_node_index();
-        self.async_state.graph_result = Some(result);
-    }
-
-    /// Set graph error
-    pub fn set_graph_error(&mut self) {
-        self.async_state.graph_result = None;
-        self.async_state.graph_pending = None;
-    }
-
     /// Trigger operation execution if pending
     pub fn trigger_operation_execution(&mut self) -> Option<OperationRequest> {
-        if let Some(ref pending) = self.async_state.pending_operation {
-            if let Some(ref client) = self.kube_client {
-                if self
-                    .operation_registry
-                    .get_by_keybinding(pending.operation_key)
-                    .is_some()
-                {
-                    let (tx, rx) = tokio::sync::oneshot::channel();
-                    let request = OperationRequest {
-                        resource_type: pending.resource_type.clone(),
-                        namespace: pending.namespace.clone(),
-                        name: pending.name.clone(),
-                        operation_key: pending.operation_key,
-                        client: client.clone(),
-                        tx,
-                    };
+        let pending = self.async_state.operation.pending()?;
+        let client = self.kube_client.as_ref()?;
+        self.operation_registry
+            .get_by_keybinding(pending.operation_key)?;
 
-                    self.async_state.last_operation_key = Some(pending.operation_key); // Store operation key for success message
-                    self.async_state.pending_operation = None;
-                    self.async_state.operation_result_rx = Some(rx);
-
-                    return Some(request);
-                }
-            }
-        }
-        None
+        let client = client.clone();
+        let (pending, tx) = self.async_state.operation.dispatch()?;
+        // Store operation key for the success message
+        self.async_state.last_operation_key = Some(pending.operation_key);
+        Some(OperationRequest {
+            resource_type: pending.resource_type,
+            namespace: pending.namespace,
+            name: pending.name,
+            operation_key: pending.operation_key,
+            client,
+            tx,
+        })
     }
 
     /// Try to get operation result
     pub fn try_get_operation_result(&mut self) -> Option<anyhow::Result<()>> {
-        if let Some(ref mut rx) = self.async_state.operation_result_rx {
-            match rx.try_recv() {
-                Ok(result) => {
-                    self.async_state.operation_result_rx = None;
-                    return Some(result);
-                }
-                Err(tokio::sync::oneshot::error::TryRecvError::Empty) => {
-                    return None;
-                }
-                Err(_) => {
-                    self.async_state.operation_result_rx = None;
-                    return Some(Err(anyhow::anyhow!("Operation failed")));
-                }
-            }
-        }
-        None
+        self.async_state.operation.try_recv()
     }
 
     /// Set operation result and update status message
     pub fn set_operation_result(&mut self, result: anyhow::Result<()>) {
         match result {
             Ok(_) => {
-                if let Some(op_key) = self.async_state.last_operation_key.take() {
-                    if let Some(operation) = self.operation_registry.get_by_keybinding(op_key) {
-                        self.set_status_message((
-                            format!("{} completed successfully", operation.name()),
-                            false,
-                        ));
-                    } else {
-                        self.set_status_message((
-                            "Operation completed successfully".to_string(),
-                            false,
-                        ));
+                let name = self
+                    .async_state
+                    .last_operation_key
+                    .take()
+                    .and_then(|op_key| self.operation_registry.get_by_keybinding(op_key))
+                    .map(|operation| operation.name().to_string());
+                match name {
+                    Some(name) => {
+                        self.set_status_message((format!("{} completed successfully", name), false))
                     }
-                } else {
-                    self.set_status_message((
+                    None => self.set_status_message((
                         "Operation completed successfully".to_string(),
                         false,
-                    ));
+                    )),
                 }
             }
             Err(e) => {
@@ -328,5 +77,13 @@ impl App {
                 self.set_status_message((format!("Operation failed: {}", e), true));
             }
         }
+    }
+
+    /// Store the graph result and start keyboard focus on the resource being
+    /// viewed (the object node) so the graph is immediately navigable with
+    /// j/k and Enter.
+    pub fn set_graph_result(&mut self, result: crate::trace::ResourceGraph) {
+        self.view_state.graph_focus_index = result.object_node_index();
+        self.async_state.graph.set_result(result);
     }
 }

--- a/src/tui/app/async_task.rs
+++ b/src/tui/app/async_task.rs
@@ -1,0 +1,194 @@
+//! Generic single-slot async fetch task.
+//!
+//! Every "fetch something for a view" flow (YAML, describe, trace, graph, …)
+//! follows the same three-phase lifecycle:
+//!
+//! 1. An event handler calls [`AsyncTask::request`] with the request key.
+//! 2. The main loop calls [`AsyncTask::dispatch`], spawns a task that does the
+//!    work, and sends the outcome through the returned sender.
+//! 3. The main loop polls [`AsyncTask::try_recv`] each tick and stores the
+//!    outcome with [`AsyncTask::set_result`] / [`AsyncTask::set_error`].
+//!
+//! `AsyncTask` owns that lifecycle once, instead of each feature carrying its
+//! own `*_pending` / `*_fetched` / `*_rx` field triplet and hand-rolled
+//! trigger/poll methods.
+
+/// A single in-flight async fetch: the queued request key, the latest result,
+/// and the channel for the running task. `K` identifies what was requested
+/// (typically a [`crate::watcher::ResourceKey`]); `T` is the fetched payload.
+pub struct AsyncTask<K, T> {
+    /// Request queued by an event handler, waiting for the main loop to dispatch.
+    pending: Option<K>,
+    /// Latest successful result (cleared when a new request is queued).
+    result: Option<T>,
+    /// Receiver for the currently running task, if any.
+    rx: Option<tokio::sync::oneshot::Receiver<anyhow::Result<T>>>,
+}
+
+/// Manual impl: the derived `Default` would require `K: Default + T: Default`
+/// even though all fields are `Option`s.
+impl<K, T> Default for AsyncTask<K, T> {
+    fn default() -> Self {
+        Self {
+            pending: None,
+            result: None,
+            rx: None,
+        }
+    }
+}
+
+impl<K, T> AsyncTask<K, T> {
+    /// Queue a new request, discarding any previous result so views show the
+    /// loading state instead of stale data.
+    pub fn request(&mut self, key: K) {
+        self.pending = Some(key);
+        self.result = None;
+    }
+
+    /// Take the queued request and arm the result channel.
+    ///
+    /// Returns the request key and the sender the spawned task must complete
+    /// with. Returns `None` when nothing is queued.
+    pub fn dispatch(&mut self) -> Option<(K, tokio::sync::oneshot::Sender<anyhow::Result<T>>)> {
+        let key = self.pending.take()?;
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.rx = Some(rx);
+        Some((key, tx))
+    }
+
+    /// Non-blocking poll for the running task's outcome.
+    ///
+    /// Returns the outcome exactly once; a dropped sender is reported as an
+    /// error. Returns `None` while the task is still running or none is.
+    pub fn try_recv(&mut self) -> Option<anyhow::Result<T>> {
+        let rx = self.rx.as_mut()?;
+        match rx.try_recv() {
+            Ok(result) => {
+                self.rx = None;
+                Some(result)
+            }
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty) => None,
+            Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
+                self.rx = None;
+                Some(Err(anyhow::anyhow!("async task dropped without a result")))
+            }
+        }
+    }
+
+    /// Store a successful result.
+    pub fn set_result(&mut self, value: T) {
+        self.result = Some(value);
+    }
+
+    /// Record a failure: drop any partial state so views fall back to their
+    /// empty/error rendering instead of a stale result.
+    pub fn set_error(&mut self) {
+        self.pending = None;
+        self.result = None;
+    }
+
+    /// The latest stored result, if any.
+    pub fn result(&self) -> Option<&T> {
+        self.result.as_ref()
+    }
+
+    /// The queued (not yet dispatched) request key, if any.
+    pub fn pending(&self) -> Option<&K> {
+        self.pending.as_ref()
+    }
+
+    /// Whether a request is queued or a task is currently running — i.e. the
+    /// view should render a loading state rather than "no data".
+    pub fn is_loading(&self) -> bool {
+        self.pending.is_some() || self.rx.is_some()
+    }
+
+    /// Reset to the idle state, dropping any queued request, running task
+    /// channel, and stored result.
+    pub fn clear(&mut self) {
+        self.pending = None;
+        self.result = None;
+        self.rx = None;
+    }
+}
+
+/// Summarize lifecycle state without requiring `T: Debug` (results can be
+/// large fetched objects) — pending key, whether a result is stored, and
+/// whether a task is in flight.
+impl<K: std::fmt::Debug, T> std::fmt::Debug for AsyncTask<K, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AsyncTask")
+            .field("pending", &self.pending)
+            .field("has_result", &self.result.is_some())
+            .field("in_flight", &self.rx.is_some())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_dispatch_recv_roundtrip() {
+        let mut task: AsyncTask<String, u32> = AsyncTask::default();
+        assert!(!task.is_loading());
+        assert!(task.dispatch().is_none());
+
+        task.request("key".to_string());
+        assert_eq!(task.pending(), Some(&"key".to_string()));
+        assert!(task.is_loading());
+
+        let (key, tx) = task.dispatch().expect("queued request should dispatch");
+        assert_eq!(key, "key");
+        assert!(task.pending().is_none());
+        assert!(task.is_loading(), "in-flight task still counts as loading");
+
+        assert!(task.try_recv().is_none(), "no result sent yet");
+        tx.send(Ok(42)).unwrap();
+        let result = task.try_recv().expect("result should arrive");
+        assert_eq!(result.unwrap(), 42);
+        assert!(
+            task.try_recv().is_none(),
+            "result is delivered exactly once"
+        );
+        assert!(!task.is_loading());
+
+        task.set_result(42);
+        assert_eq!(task.result(), Some(&42));
+    }
+
+    #[test]
+    fn request_clears_previous_result() {
+        let mut task: AsyncTask<String, u32> = AsyncTask::default();
+        task.set_result(1);
+        task.request("next".to_string());
+        assert!(task.result().is_none());
+    }
+
+    #[test]
+    fn dropped_sender_reports_error() {
+        let mut task: AsyncTask<String, u32> = AsyncTask::default();
+        task.request("key".to_string());
+        let (_, tx) = task.dispatch().unwrap();
+        drop(tx);
+        let result = task.try_recv().expect("closed channel should surface");
+        assert!(result.is_err());
+        assert!(!task.is_loading());
+    }
+
+    #[test]
+    fn set_error_and_clear_reset_state() {
+        let mut task: AsyncTask<String, u32> = AsyncTask::default();
+        task.request("key".to_string());
+        task.set_error();
+        assert!(task.pending().is_none());
+        assert!(task.result().is_none());
+
+        task.request("key2".to_string());
+        let _ = task.dispatch();
+        task.clear();
+        assert!(!task.is_loading());
+        assert!(task.try_recv().is_none());
+    }
+}

--- a/src/tui/app/core.rs
+++ b/src/tui/app/core.rs
@@ -1,7 +1,8 @@
 //! Application state and main TUI logic
 
 use super::state::{
-    AsyncOperationState, ControllerPodState, HealthFilter, SelectionState, UIState, View, ViewState,
+    AsyncOperationState, ControllerPodState, HealthFilter, KubeEventStore, SelectionState, UIState,
+    View, ViewState,
 };
 use crate::tui::{OperationRegistry, Theme};
 use crate::watcher::ResourceState;
@@ -31,6 +32,8 @@ pub struct App {
     pub(crate) namespace_hotkeys: Vec<String>,
     pub(crate) pending_context_switch: Option<String>,
     pub(crate) controller_pods: ControllerPodState,
+    /// Live Kubernetes events feed (populated while the events view is open).
+    pub(crate) kube_events: KubeEventStore,
     /// Path to the active log file, shown on the connection error screen.
     pub(crate) log_path: Option<std::path::PathBuf>,
     /// Watchers currently in a degraded (erroring/reconnecting) state.
@@ -80,6 +83,7 @@ impl App {
             namespace_hotkeys: Self::build_namespace_hotkeys(&config, Vec::new()),
             pending_context_switch: None,
             controller_pods: ControllerPodState::default(),
+            kube_events: KubeEventStore::default(),
             log_path: None,
             degraded_watchers: HashSet::new(),
         }
@@ -294,6 +298,59 @@ impl App {
 
     pub fn set_watcher(&mut self, watcher: crate::watcher::ResourceWatcher) {
         self.watcher = Some(watcher);
+        // A replacement watcher (context switch) starts without the lazily
+        // started events watch — rearm it if the events view is showing.
+        if self.view_state.current_view == View::EventList {
+            self.start_kube_events_watch();
+        }
+    }
+
+    /// Start the Kubernetes events watcher (no-op if already running).
+    pub(crate) fn start_kube_events_watch(&mut self) {
+        if let Some(ref mut watcher) = self.watcher {
+            if let Err(e) = watcher.watch_kube_events() {
+                tracing::warn!("Failed to start events watcher: {}", e);
+                self.set_status_message((format!("Failed to watch events: {}", e), true));
+            }
+        }
+    }
+
+    /// Stop the events watcher and drop the collected feed. Called when the
+    /// events view is left; the watcher re-lists everything on next open, so
+    /// keeping stale entries would only risk showing deleted events.
+    pub(crate) fn stop_kube_events_watch(&mut self) {
+        if let Some(ref mut watcher) = self.watcher {
+            watcher.stop_kube_events();
+        }
+        self.kube_events.clear();
+    }
+
+    /// The live events feed filtered by the list filter (matches type, reason,
+    /// object, source, namespace and message), newest first. Returns owned
+    /// clones so callers can hold the list while mutating view state.
+    pub(crate) fn filtered_kube_events(&self) -> Vec<crate::kube::events::KubeEventInfo> {
+        let filter = self.view_state.filter.to_lowercase();
+        self.kube_events
+            .sorted_events()
+            .into_iter()
+            .filter(|event| {
+                if filter.is_empty() {
+                    return true;
+                }
+                [
+                    event.event_type.as_str(),
+                    event.reason.as_str(),
+                    event.message.as_str(),
+                    event.source.as_str(),
+                    event.involved_kind.as_str(),
+                    event.involved_namespace.as_str(),
+                    event.involved_name.as_str(),
+                ]
+                .iter()
+                .any(|text| text.to_lowercase().contains(&filter))
+            })
+            .cloned()
+            .collect()
     }
 
     pub fn set_context(&mut self, context: String) {
@@ -320,6 +377,7 @@ impl App {
         self.state.clear();
         self.resource_objects.clear();
         self.controller_pods.clear();
+        self.kube_events.clear();
         self.degraded_watchers.clear();
         self.view_state.selected_index = 0;
         self.view_state.scroll_offset = 0;
@@ -444,19 +502,57 @@ impl App {
 
     /// Get the currently selected resource based on the current view
     /// Returns ResourceInfo if a resource is selected, None otherwise
-    pub(crate) fn get_current_resource(&self) -> Option<crate::watcher::ResourceInfo> {
+    /// The resource the current view is pointing at, regardless of view type:
+    /// the selected row in resource lists, the selected event's involved
+    /// object in the events feed, the focused (non-aggregate) node in the
+    /// graph, or the stored selection in nested detail-style views.
+    ///
+    /// This is the single resolver behind "act on the current resource" keys
+    /// (YAML, describe, trace, graph, history, operations), so they work the
+    /// same from every view. The target is not necessarily a watched Flux
+    /// resource — an event may be about a Pod, a graph node may be a managed
+    /// Deployment; callers that need watched state use
+    /// [`Self::get_current_resource`].
+    pub(crate) fn view_target(&self) -> Option<crate::watcher::ResourceKey> {
+        use crate::watcher::ResourceKey;
         match self.view_state.current_view {
             View::ResourceList | View::ResourceFavorites => {
                 let resources = self.get_filtered_resources();
-                resources.get(self.view_state.selected_index).cloned()
+                let resource = resources.get(self.view_state.selected_index)?;
+                Some(ResourceKey::new(
+                    resource.resource_type.clone(),
+                    resource.namespace.clone(),
+                    resource.name.clone(),
+                ))
             }
-            View::ResourceDetail | View::ResourceDescribe => self
+            View::EventList => {
+                let events = self.filtered_kube_events();
+                let event = events.get(self.view_state.selected_index)?;
+                Some(ResourceKey::new(
+                    event.involved_kind.clone(),
+                    event.involved_namespace.clone(),
+                    event.involved_name.clone(),
+                ))
+            }
+            View::ResourceGraph => self.focused_graph_node_target(),
+            View::ResourceDetail
+            | View::ResourceDescribe
+            | View::ResourceYAML
+            | View::ResourceTrace
+            | View::ResourceHistory => self
                 .selection_state
                 .selected_resource_key
-                .as_ref()
-                .and_then(|key| self.state.get(key)),
-            _ => None,
+                .as_deref()
+                .and_then(ResourceKey::parse),
+            View::Help => None,
         }
+    }
+
+    /// The watched Flux resource the current view points at, when the
+    /// [`Self::view_target`] is one flux9s watches.
+    pub(crate) fn get_current_resource(&self) -> Option<crate::watcher::ResourceInfo> {
+        self.view_target()
+            .and_then(|rk| self.state.get(&rk.to_key_string()))
     }
 
     pub fn set_view_trace(&mut self) {
@@ -678,36 +774,14 @@ impl std::fmt::Debug for App {
             .field("resource_objects", &"<Arc<RwLock<HashMap>>>")
             .field("watcher", &"<Option<ResourceWatcher>>")
             .field("kube_client", &"<Option<kube::Client>>")
-            .field("yaml_fetch_pending", &self.async_state.yaml_fetch_pending)
-            .field("yaml_fetched", &self.async_state.yaml_fetched.is_some())
-            .field("yaml_fetch_rx", &self.async_state.yaml_fetch_rx.is_some())
-            .field(
-                "describe_fetch_pending",
-                &self.async_state.describe_fetch_pending,
-            )
-            .field(
-                "describe_fetched",
-                &self.async_state.describe_fetched.is_some(),
-            )
-            .field(
-                "describe_fetch_rx",
-                &self.async_state.describe_fetch_rx.is_some(),
-            )
-            .field("trace_pending", &self.async_state.trace_pending)
-            .field("trace_result", &self.async_state.trace_result.is_some())
-            .field(
-                "trace_result_rx",
-                &self.async_state.trace_result_rx.is_some(),
-            )
+            .field("yaml_task", &self.async_state.yaml)
+            .field("describe_task", &self.async_state.describe)
+            .field("trace_task", &self.async_state.trace)
             .field("trace_scroll_offset", &self.view_state.trace_scroll_offset)
             .field("show_splash", &self.ui_state.show_splash)
             .field("splash_start_time", &self.ui_state.splash_start_time)
             .field("operation_registry", &"<OperationRegistry>")
-            .field("pending_operation", &self.async_state.pending_operation)
-            .field(
-                "operation_result_rx",
-                &self.async_state.operation_result_rx.is_some(),
-            )
+            .field("operation_task", &self.async_state.operation)
             .field("last_operation_key", &self.async_state.last_operation_key)
             .field(
                 "confirmation_pending",
@@ -732,12 +806,7 @@ impl std::fmt::Debug for App {
                 &self.view_state.history_scroll_offset,
             )
             .field("graph_scroll_offset", &self.view_state.graph_scroll_offset)
-            .field("graph_pending", &self.async_state.graph_pending)
-            .field("graph_result", &self.async_state.graph_result.is_some())
-            .field(
-                "graph_result_rx",
-                &self.async_state.graph_result_rx.is_some(),
-            )
+            .field("graph_task", &self.async_state.graph)
             .field("previous_list_view", &self.view_state.previous_list_view)
             .finish()
     }

--- a/src/tui/app/events.rs
+++ b/src/tui/app/events.rs
@@ -25,6 +25,7 @@ const COMMAND_TABLE: &[(fn(&str) -> bool, CommandHandler)] = &[
     (commands::is_healthy_command, App::cmd_filter_healthy),
     (commands::is_unhealthy_command, App::cmd_filter_unhealthy),
     (commands::is_favorites_command, App::cmd_show_favorites),
+    (commands::is_events_command, App::cmd_show_events),
     (commands::is_all_command, App::cmd_show_all),
 ];
 
@@ -41,8 +42,11 @@ impl App {
         } else if let Some(offset) = view.scroll_offset_mut(&mut self.view_state) {
             *offset += amount;
         } else {
-            let resources = self.get_filtered_resources();
-            let max_index = resources.len().saturating_sub(1);
+            let max_index = if view == View::EventList {
+                self.filtered_kube_events().len().saturating_sub(1)
+            } else {
+                self.get_filtered_resources().len().saturating_sub(1)
+            };
             self.view_state.selected_index =
                 (self.view_state.selected_index + amount).min(max_index);
         }
@@ -333,12 +337,11 @@ impl App {
             crossterm::event::KeyCode::Char('t') => {
                 // Trace command - works from list, favorites, and detail view
                 if let Some(resource) = self.get_current_resource() {
-                    self.async_state.trace_pending = Some(ResourceKey::new(
+                    self.async_state.trace.request(ResourceKey::new(
                         resource.resource_type.clone(),
                         resource.namespace.clone(),
                         resource.name.clone(),
                     ));
-                    self.async_state.trace_result = None;
                     self.view_state.trace_scroll_offset = 0;
                 }
             }
@@ -395,8 +398,7 @@ impl App {
             crossterm::event::KeyCode::Char('y') => {
                 // View YAML - trigger async fetch
                 if let Some(key) = self.prepare_selected_resource_key_for_nested_view() {
-                    self.async_state.yaml_fetch_pending = Some(key);
-                    self.async_state.yaml_fetched = None;
+                    self.async_state.yaml.request(key);
                     self.view_state.yaml_scroll_offset = 0;
                     self.view_state.text_search.clear();
                     self.view_state.current_view = View::ResourceYAML;
@@ -404,8 +406,7 @@ impl App {
             }
             crossterm::event::KeyCode::Char('d') => {
                 if let Some(key) = self.prepare_selected_resource_key_for_nested_view() {
-                    self.async_state.describe_fetch_pending = Some(key);
-                    self.async_state.describe_fetched = None;
+                    self.async_state.describe.request(key);
                     self.view_state.describe_scroll_offset = 0;
                     self.view_state.text_search.clear();
                     self.view_state.current_view = View::ResourceDescribe;
@@ -416,6 +417,10 @@ impl App {
             {
                 // Drill into the focused graph node's resource.
                 self.navigate_to_focused_graph_node();
+            }
+            crossterm::event::KeyCode::Enter if self.view_state.current_view == View::EventList => {
+                // Jump to the event's involved resource when flux9s watches it.
+                self.navigate_to_selected_event_resource();
             }
             crossterm::event::KeyCode::Enter if self.view_state.current_view.is_list_view() => {
                 // Save current view as previous list view before navigating
@@ -524,7 +529,9 @@ impl App {
                     }
 
                     // Save current view as previous list view before navigating
-                    if self.view_state.current_view.is_list_view() {
+                    if self.view_state.current_view.is_list_view()
+                        || self.view_state.current_view == View::EventList
+                    {
                         self.view_state.previous_list_view = self.view_state.current_view;
                     }
 
@@ -536,12 +543,11 @@ impl App {
                     );
 
                     self.selection_state.selected_resource_key = Some(key.clone());
-                    self.async_state.graph_pending = Some(ResourceKey {
+                    self.async_state.graph.request(ResourceKey {
                         resource_type: resource.resource_type.clone(),
                         namespace: resource.namespace.clone(),
                         name: resource.name.clone(),
                     });
-                    self.async_state.graph_result = None; // Clear previous graph
                     self.view_state.graph_scroll_offset = 0; // Reset scroll
                     self.view_state.graph_focus_index = None; // Reset focus (set when graph loads)
                     self.view_state.current_view = View::ResourceGraph;
@@ -562,6 +568,10 @@ impl App {
                         self.view_state.text_search.clear();
                     }
                 } else if self.view_state.current_view == View::ResourceFavorites {
+                    self.view_state.current_view = View::ResourceList;
+                    self.selection_state.selected_resource_key = None;
+                } else if self.view_state.current_view == View::EventList {
+                    self.stop_kube_events_watch();
                     self.view_state.current_view = View::ResourceList;
                     self.selection_state.selected_resource_key = None;
                 }
@@ -773,7 +783,7 @@ impl App {
     /// Clamps at the ends rather than wrapping so the direction stays intuitive.
     /// Auto-scrolling to keep the focused node visible is handled by the renderer.
     fn move_graph_focus(&mut self, forward: bool) {
-        let Some(graph) = self.async_state.graph_result.as_ref() else {
+        let Some(graph) = self.async_state.graph.result() else {
             return;
         };
         let order = graph.focus_order();
@@ -795,47 +805,55 @@ impl App {
         self.view_state.graph_focus_index = Some(order[next_pos]);
     }
 
+    /// Identity of the keyboard-focused graph node when it is an individual
+    /// resource. Aggregate nodes (workload/resource groups) and external
+    /// upstream URLs have no single resource to act on, so they resolve to
+    /// `None`.
+    pub(crate) fn focused_graph_node_target(&self) -> Option<ResourceKey> {
+        use crate::trace::NodeType;
+        let node = self.async_state.graph.result().and_then(|graph| {
+            self.view_state
+                .graph_focus_index
+                .and_then(|idx| graph.nodes.get(idx))
+        })?;
+        if matches!(
+            node.node_type,
+            NodeType::WorkloadGroup | NodeType::ResourceGroup | NodeType::Upstream
+        ) {
+            return None;
+        }
+        Some(ResourceKey::new(
+            node.kind.clone(),
+            node.namespace.clone(),
+            node.name.clone(),
+        ))
+    }
+
     /// Open the detail view for the focused graph node when it maps to a watched
     /// resource. Aggregate nodes (workload/resource groups) and external upstream
     /// URLs are not directly navigable and just show a hint instead.
     fn navigate_to_focused_graph_node(&mut self) {
-        use crate::trace::NodeType;
-
-        // Pull the owned identity out first so the immutable borrow of the graph
-        // ends before we mutate view/selection state below.
-        let Some((node_type, kind, namespace, name)) = self
+        let has_focused_node = self
             .async_state
-            .graph_result
-            .as_ref()
+            .graph
+            .result()
             .and_then(|graph| {
                 self.view_state
                     .graph_focus_index
                     .and_then(|idx| graph.nodes.get(idx))
             })
-            .map(|n| {
-                (
-                    n.node_type,
-                    n.kind.clone(),
-                    n.namespace.clone(),
-                    n.name.clone(),
-                )
-            })
-        else {
+            .is_some();
+        let Some(rk) = self.focused_graph_node_target() else {
+            if has_focused_node {
+                self.set_status_message((
+                    "Aggregate node — select an individual Flux resource to open it".to_string(),
+                    false,
+                ));
+            }
             return;
         };
 
-        if matches!(
-            node_type,
-            NodeType::WorkloadGroup | NodeType::ResourceGroup | NodeType::Upstream
-        ) {
-            self.set_status_message((
-                "Aggregate node — select an individual Flux resource to open it".to_string(),
-                false,
-            ));
-            return;
-        }
-
-        let key = crate::watcher::resource_key(&namespace, &name, &kind);
+        let key = rk.to_key_string();
         if self.state.get(&key).is_some() {
             self.selection_state.selected_resource_key = Some(key);
             // Remember to return to the graph (not the list) when the user backs
@@ -844,17 +862,23 @@ impl App {
             self.view_state.current_view = View::ResourceDetail;
         } else {
             self.set_status_message((
-                format!("{} {} is not in the current view", kind, name),
+                format!(
+                    "{} {} is not in the current view",
+                    rk.resource_type, rk.name
+                ),
                 false,
             ));
         }
     }
 
-    /// If the detail view was entered by drilling into a graph node, consume and
-    /// return the stored back target (the graph). Returns `None` for any other
-    /// view or entry path, leaving normal back-to-list behaviour in place.
+    /// If the current nested view was entered by drilling into a graph node
+    /// (detail via Enter, or YAML/describe/etc. directly on the focused node),
+    /// consume and return the stored back target (the graph). Returns `None`
+    /// for any other entry path, leaving normal back-to-list behaviour in place.
     fn detail_graph_back(&mut self) -> Option<View> {
-        if self.view_state.current_view == View::ResourceDetail {
+        if self.view_state.current_view.is_nested_view()
+            && self.view_state.current_view != View::ResourceGraph
+        {
             self.view_state.detail_back_view.take()
         } else {
             None
@@ -895,6 +919,11 @@ impl App {
                 self.view_state.current_view = View::ResourceList;
                 None
             }
+            View::EventList => {
+                self.stop_kube_events_watch();
+                self.view_state.current_view = View::ResourceList;
+                None
+            }
             View::Help => {
                 self.view_state.current_view = View::ResourceList;
                 None
@@ -923,25 +952,58 @@ impl App {
         }
     }
 
-    fn prepare_selected_resource_key_for_nested_view(&mut self) -> Option<String> {
-        match self.view_state.current_view {
-            View::ResourceList | View::ResourceFavorites => {
-                self.view_state.previous_list_view = self.view_state.current_view;
-                let resources = self.get_filtered_resources();
-                let resource = resources.get(self.view_state.selected_index)?;
-                let key = crate::watcher::resource_key(
-                    &resource.namespace,
-                    &resource.name,
-                    &resource.resource_type,
-                );
-                self.selection_state.selected_resource_key = Some(key.clone());
-                Some(key)
-            }
-            View::ResourceDetail | View::ResourceDescribe => {
-                self.selection_state.selected_resource_key.clone()
-            }
-            _ => None,
+    /// Open the detail view for the resource the selected event is about,
+    /// when it is a Flux resource flux9s is watching. Back returns to the
+    /// events feed (the events watcher keeps running meanwhile).
+    fn navigate_to_selected_event_resource(&mut self) {
+        let events = self.filtered_kube_events();
+        let Some(event) = events.get(self.view_state.selected_index) else {
+            return;
+        };
+
+        let key = crate::watcher::resource_key(
+            &event.involved_namespace,
+            &event.involved_name,
+            &event.involved_kind,
+        );
+        if self.state.get(&key).is_none() {
+            // Not in the watch state: outside the namespace scope, a non-Flux
+            // kind, or its watcher isn't running. Name the namespace so a
+            // scope mismatch is visible, and point at the keys that still work.
+            self.set_status_message((
+                format!(
+                    "{} (ns: {}) is not in the watched resources — press y/d to view it",
+                    event.object_label(),
+                    event.involved_namespace
+                ),
+                false,
+            ));
+            return;
         }
+
+        self.view_state.previous_list_view = View::EventList;
+        self.view_state.detail_back_view = None;
+        self.selection_state.selected_resource_key = Some(key);
+        self.view_state.current_view = View::ResourceDetail;
+    }
+
+    fn prepare_selected_resource_key_for_nested_view(&mut self) -> Option<ResourceKey> {
+        let rk = self.view_target()?;
+        match self.view_state.current_view {
+            // Root list-style views: remember where Back should return to and
+            // drop any stale graph back-target from an earlier drill-down.
+            View::ResourceList | View::ResourceFavorites | View::EventList => {
+                self.view_state.previous_list_view = self.view_state.current_view;
+                self.view_state.detail_back_view = None;
+            }
+            // Drilling out of the graph: Back returns to the graph.
+            View::ResourceGraph => {
+                self.view_state.detail_back_view = Some(View::ResourceGraph);
+            }
+            _ => {}
+        }
+        self.selection_state.selected_resource_key = Some(rk.to_key_string());
+        Some(rk)
     }
 
     fn handle_operation_key(&mut self, op_key: char) {
@@ -1056,7 +1118,7 @@ impl App {
         if self.operation_registry.get_by_keybinding(op_key).is_some() && self.kube_client.is_some()
         {
             // Mark operation as pending - will be executed in main loop
-            self.async_state.pending_operation = Some(PendingOperation::new(
+            self.async_state.operation.request(PendingOperation::new(
                 resource_type.to_string(),
                 namespace.to_string(),
                 name.to_string(),
@@ -1270,8 +1332,7 @@ impl App {
             // No argument: trace the currently selected resource.
             if let Some(key) = &self.selection_state.selected_resource_key {
                 if let Some(rk) = ResourceKey::parse(key) {
-                    self.async_state.trace_pending = Some(rk);
-                    self.async_state.trace_result = None;
+                    self.async_state.trace.request(rk);
                 } else {
                     tracing::warn!("Failed to parse resource key for trace command: {}", key);
                     self.ui_state.status_message =
@@ -1302,12 +1363,11 @@ impl App {
                 .namespace()
                 .clone()
                 .unwrap_or_else(|| "default".to_string());
-            self.async_state.trace_pending = Some(ResourceKey::new(
+            self.async_state.trace.request(ResourceKey::new(
                 resource_type.to_string(),
                 namespace,
                 parts[1].to_string(),
             ));
-            self.async_state.trace_result = None;
         } else {
             self.set_status_message((
                 "Usage: :trace <resource-type>/<name> or :trace (for selected)".to_string(),
@@ -1368,6 +1428,7 @@ impl App {
             self.state().clear();
             self.resource_objects.clear();
             self.controller_pods.clear();
+            self.kube_events.clear();
             self.degraded_watchers.clear();
 
             if let Some(ref mut watcher) = self.watcher {
@@ -1401,9 +1462,22 @@ impl App {
         self.reset_list_position();
     }
 
-    /// `:all` — clear resource-type and health filters to show everything.
+    /// `:events` — open the live Kubernetes events feed for the current
+    /// namespace scope, lazily starting the events watcher.
+    fn cmd_show_events(&mut self, _cmd: &str) {
+        self.start_kube_events_watch();
+        self.view_state.current_view = View::EventList;
+        self.reset_list_position();
+    }
+
+    /// `:all` — clear resource-type and health filters and return to the main
+    /// resource list (also from the favorites and events views).
     fn cmd_show_all(&mut self, _cmd: &str) {
         if self.view_state.current_view == View::ResourceFavorites {
+            self.view_state.current_view = View::ResourceList;
+        }
+        if self.view_state.current_view == View::EventList {
+            self.stop_kube_events_watch();
             self.view_state.current_view = View::ResourceList;
         }
         if self.view_state.selected_resource_type.is_some() {
@@ -1502,7 +1576,11 @@ mod tests {
         assert_eq!(result, None);
         assert_eq!(app.view_state.current_view, View::ResourceDescribe);
         assert_eq!(
-            app.async_state.describe_fetch_pending.as_deref(),
+            app.async_state
+                .describe
+                .pending()
+                .map(ResourceKey::to_key_string)
+                .as_deref(),
             Some("Kustomization:flux-system:my-kustomization")
         );
         assert!(app.async_state.confirmation_pending.is_none());
@@ -1519,7 +1597,7 @@ mod tests {
         assert_eq!(result, None);
         assert!(app.async_state.confirmation_pending.is_some());
         assert_eq!(app.view_state.current_view, View::ResourceList);
-        assert!(app.async_state.pending_operation.is_none());
+        assert!(app.async_state.operation.pending().is_none());
     }
 
     #[test]
@@ -1555,7 +1633,7 @@ mod tests {
 
         assert_eq!(result, None);
         assert!(app.async_state.confirmation_pending.is_none());
-        assert!(app.async_state.pending_operation.is_none());
+        assert!(app.async_state.operation.pending().is_none());
         assert_eq!(
             app.ui_state.status_message,
             Some((
@@ -1872,5 +1950,241 @@ mod tests {
         assert_eq!(app.view_state.detail_back_view, None);
         app.handle_key(make_key(KeyCode::Esc));
         assert_eq!(app.view_state.current_view, View::ResourceList);
+    }
+
+    fn add_kube_event(app: &mut App, uid: &str, kind: &str, name: &str) {
+        let info = crate::kube::events::KubeEventInfo::from_json(&serde_json::json!({
+            "metadata": {"uid": uid, "namespace": "flux-system"},
+            "involvedObject": {
+                "kind": kind,
+                "namespace": "flux-system",
+                "name": name
+            },
+            "type": "Normal",
+            "reason": "Test",
+            "message": "test",
+            "lastTimestamp": "2026-07-01T12:30:00Z"
+        }))
+        .unwrap();
+        app.kube_events.upsert(info);
+    }
+
+    #[test]
+    fn events_command_opens_event_list_view() {
+        let mut app = create_test_app(false);
+        app.ui_state.command_buffer = "events".to_string();
+
+        let result = app.execute_command();
+
+        assert_eq!(result, None);
+        assert_eq!(app.view_state.current_view, View::EventList);
+    }
+
+    #[test]
+    fn esc_from_event_list_returns_to_resource_list_and_clears_feed() {
+        let mut app = create_test_app(false);
+        add_kube_event(&mut app, "uid-1", "Kustomization", "my-kustomization");
+        app.view_state.current_view = View::EventList;
+
+        let result = app.handle_key(make_key(KeyCode::Esc));
+
+        assert_eq!(result, None);
+        assert_eq!(app.view_state.current_view, View::ResourceList);
+        assert!(
+            app.kube_events.is_empty(),
+            "leaving the events view drops the collected feed"
+        );
+    }
+
+    #[test]
+    fn enter_on_event_opens_watched_resource_detail() {
+        let mut app = create_test_app(false);
+        add_resource(&mut app);
+        add_kube_event(&mut app, "uid-1", "Kustomization", "my-kustomization");
+        app.view_state.current_view = View::EventList;
+        app.view_state.selected_index = 0;
+
+        app.handle_key(make_key(KeyCode::Enter));
+
+        assert_eq!(app.view_state.current_view, View::ResourceDetail);
+        assert_eq!(
+            app.selection_state.selected_resource_key.as_deref(),
+            Some("Kustomization:flux-system:my-kustomization")
+        );
+        // Back returns to the events feed, not the resource list
+        assert_eq!(app.view_state.previous_list_view, View::EventList);
+        app.handle_key(make_key(KeyCode::Esc));
+        assert_eq!(app.view_state.current_view, View::EventList);
+    }
+
+    #[test]
+    fn enter_on_event_for_unwatched_object_stays_in_event_list() {
+        let mut app = create_test_app(false);
+        add_kube_event(&mut app, "uid-1", "Pod", "some-pod");
+        app.view_state.current_view = View::EventList;
+        app.view_state.selected_index = 0;
+
+        app.handle_key(make_key(KeyCode::Enter));
+
+        assert_eq!(app.view_state.current_view, View::EventList);
+        assert!(
+            app.ui_state
+                .status_message
+                .as_ref()
+                .is_some_and(|(msg, _)| msg.contains("Pod/some-pod")
+                    && msg.contains("ns: flux-system")
+                    && msg.contains("y/d")),
+            "names the object + namespace and points at y/d"
+        );
+    }
+
+    #[test]
+    fn all_command_returns_from_event_list_and_clears_filters() {
+        let mut app = create_test_app(false);
+        add_kube_event(&mut app, "uid-1", "Kustomization", "my-kustomization");
+        app.view_state.current_view = View::EventList;
+        app.view_state.selected_resource_type = Some("HelmChart".to_string());
+        app.view_state.health_filter = HealthFilter::Unhealthy;
+
+        app.ui_state.command_buffer = "all".to_string();
+        let result = app.execute_command();
+
+        assert_eq!(result, None);
+        assert_eq!(app.view_state.current_view, View::ResourceList);
+        assert_eq!(app.view_state.selected_resource_type, None);
+        assert_eq!(app.view_state.health_filter, HealthFilter::All);
+        assert!(
+            app.kube_events.is_empty(),
+            "leaving the events view via :all drops the feed"
+        );
+    }
+
+    #[test]
+    fn y_and_d_work_from_event_list_on_involved_object() {
+        let mut app = create_test_app(false);
+        add_kube_event(&mut app, "uid-1", "Kustomization", "my-kustomization");
+        app.view_state.current_view = View::EventList;
+        app.view_state.selected_index = 0;
+
+        app.handle_key(make_key(KeyCode::Char('y')));
+
+        assert_eq!(app.view_state.current_view, View::ResourceYAML);
+        assert_eq!(
+            app.async_state
+                .yaml
+                .pending()
+                .map(ResourceKey::to_key_string)
+                .as_deref(),
+            Some("Kustomization:flux-system:my-kustomization")
+        );
+        // Back returns to the events feed, not the resource list
+        assert_eq!(app.view_state.previous_list_view, View::EventList);
+        app.handle_key(make_key(KeyCode::Esc));
+        assert_eq!(app.view_state.current_view, View::EventList);
+
+        app.handle_key(make_key(KeyCode::Char('d')));
+        assert_eq!(app.view_state.current_view, View::ResourceDescribe);
+        assert_eq!(
+            app.async_state
+                .describe
+                .pending()
+                .map(ResourceKey::to_key_string)
+                .as_deref(),
+            Some("Kustomization:flux-system:my-kustomization")
+        );
+    }
+
+    #[test]
+    fn view_target_resolves_current_resource_from_every_view() {
+        let mut app = create_test_app(false);
+        add_resource(&mut app);
+        add_kube_event(&mut app, "uid-1", "Kustomization", "my-kustomization");
+
+        // Events feed: the selected event's involved object — including for
+        // operations/trace/graph/history, which resolve via get_current_resource
+        app.view_state.current_view = View::EventList;
+        app.view_state.selected_index = 0;
+        assert_eq!(
+            app.view_target().map(|rk| rk.to_key_string()).as_deref(),
+            Some("Kustomization:flux-system:my-kustomization")
+        );
+        assert!(
+            app.get_current_resource()
+                .is_some_and(|r| r.name == "my-kustomization"),
+            "watched involved objects resolve for operations from the events feed"
+        );
+
+        // Resource list: the selected row
+        app.view_state.current_view = View::ResourceList;
+        assert_eq!(
+            app.view_target().map(|rk| rk.to_key_string()).as_deref(),
+            Some("Kustomization:flux-system:my-kustomization")
+        );
+
+        // Nested views: the stored selection
+        app.selection_state.selected_resource_key =
+            Some("Kustomization:flux-system:my-kustomization".to_string());
+        for view in [
+            View::ResourceDetail,
+            View::ResourceDescribe,
+            View::ResourceYAML,
+            View::ResourceTrace,
+            View::ResourceHistory,
+        ] {
+            app.view_state.current_view = view;
+            assert!(app.view_target().is_some(), "{view:?} should resolve");
+        }
+    }
+
+    #[test]
+    fn yaml_from_focused_graph_node_returns_to_graph_on_esc() {
+        let mut app = app_on_graph();
+        // Focus starts on the object node (a real resource)
+        app.handle_key(make_key(KeyCode::Char('y')));
+
+        assert_eq!(app.view_state.current_view, View::ResourceYAML);
+        assert_eq!(
+            app.async_state
+                .yaml
+                .pending()
+                .map(ResourceKey::to_key_string)
+                .as_deref(),
+            Some("Kustomization:flux-system:my-kustomization")
+        );
+
+        app.handle_key(make_key(KeyCode::Esc));
+        assert_eq!(
+            app.view_state.current_view,
+            View::ResourceGraph,
+            "Back from a view opened off a graph node returns to the graph"
+        );
+    }
+
+    #[test]
+    fn yaml_on_aggregate_graph_node_does_nothing() {
+        let mut app = app_on_graph();
+        // Move focus to the workload group (aggregate) node
+        app.view_state.graph_focus_index = Some(2);
+
+        app.handle_key(make_key(KeyCode::Char('y')));
+
+        assert_eq!(app.view_state.current_view, View::ResourceGraph);
+        assert!(app.async_state.yaml.pending().is_none());
+    }
+
+    #[test]
+    fn event_list_filter_narrows_feed() {
+        let mut app = create_test_app(false);
+        add_kube_event(&mut app, "uid-1", "Kustomization", "podinfo");
+        add_kube_event(&mut app, "uid-2", "HelmRelease", "cert-manager");
+        app.view_state.current_view = View::EventList;
+
+        app.view_state.filter = "helmrelease".to_string();
+        let filtered = app.filtered_kube_events();
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].involved_name, "cert-manager");
+
+        app.view_state.filter.clear();
+        assert_eq!(app.filtered_kube_events().len(), 2);
     }
 }

--- a/src/tui/app/mod.rs
+++ b/src/tui/app/mod.rs
@@ -5,6 +5,8 @@
 
 pub mod state;
 
+pub mod async_task;
+
 mod async_ops;
 mod core;
 mod events;

--- a/src/tui/app/rendering.rs
+++ b/src/tui/app/rendering.rs
@@ -411,8 +411,8 @@ impl App {
                         &self.selection_state.selected_resource_key,
                         &self.state,
                         &self.resource_objects,
-                        &self.async_state.describe_fetched,
-                        &self.async_state.describe_fetch_pending,
+                        self.async_state.describe.result(),
+                        self.async_state.describe.is_loading(),
                         &mut self.view_state.describe_scroll_offset,
                         &mut self.view_state.text_search,
                         &self.theme,
@@ -425,8 +425,8 @@ impl App {
                         &self.selection_state.selected_resource_key,
                         &self.state,
                         &self.resource_objects,
-                        &self.async_state.yaml_fetched,
-                        &self.async_state.yaml_fetch_pending,
+                        self.async_state.yaml.result(),
+                        self.async_state.yaml.is_loading(),
                         &mut self.view_state.yaml_scroll_offset,
                         &mut self.view_state.text_search,
                         &self.theme,
@@ -437,8 +437,8 @@ impl App {
                         f,
                         area,
                         &self.selection_state.selected_resource_key,
-                        &self.async_state.trace_result,
-                        &self.async_state.trace_pending,
+                        self.async_state.trace.result(),
+                        self.async_state.trace.is_loading(),
                         &mut self.view_state.trace_scroll_offset,
                         &mut self.view_state.text_search,
                         &self.theme,
@@ -466,8 +466,8 @@ impl App {
                         f,
                         area,
                         &self.selection_state.selected_resource_key,
-                        &self.async_state.graph_result,
-                        &self.async_state.graph_pending,
+                        self.async_state.graph.result(),
+                        self.async_state.graph.is_loading(),
                         &mut self.view_state.graph_scroll_offset,
                         self.view_state.graph_focus_index,
                         &self.theme,
@@ -510,6 +510,20 @@ impl App {
                             .style(Style::default().fg(self.theme.text_secondary));
                         f.render_widget(paragraph, area);
                     }
+                }
+                View::EventList => {
+                    let events = self.filtered_kube_events();
+                    views::render_kube_events(
+                        f,
+                        area,
+                        &events,
+                        self.kube_events.len(),
+                        self.view_state.selected_index,
+                        &mut self.view_state.scroll_offset,
+                        &self.view_state.filter,
+                        self.namespace.is_none(),
+                        &self.theme,
+                    );
                 }
                 View::Help => {
                     render_help(f, area, &self.theme, self.namespace_hotkeys());

--- a/src/tui/app/state.rs
+++ b/src/tui/app/state.rs
@@ -3,6 +3,7 @@
 //! This module contains state sub-structures that organize the App's fields
 //! into logical groupings for better maintainability and testability.
 
+use crate::tui::app::async_task::AsyncTask;
 use crate::tui::submenu::SubmenuState;
 use crate::watcher::ResourceKey;
 use std::collections::HashSet;
@@ -18,6 +19,9 @@ pub enum View {
     ResourceGraph,
     ResourceFavorites,
     ResourceHistory,
+    /// Live Kubernetes events feed, opened with `:events`. The events watcher
+    /// runs only while this view (or a detail view opened from it) is active.
+    EventList,
     #[allow(dead_code)] // Reserved for future alternative help view implementation
     Help,
 }
@@ -304,59 +308,35 @@ impl UIState {
     }
 }
 
-/// Async operation state (pending operations and their result channels)
+/// Async operation state: one [`AsyncTask`] slot per view fetch, plus the
+/// mutation-operation flow (which carries confirmation state alongside).
 #[derive(Debug, Default)]
 pub struct AsyncOperationState {
-    // YAML fetch
-    pub yaml_fetch_pending: Option<String>,
-    pub yaml_fetched: Option<serde_json::Value>,
-    pub yaml_fetch_rx: Option<tokio::sync::oneshot::Receiver<anyhow::Result<serde_json::Value>>>,
+    /// Full-object fetch backing the YAML view.
+    pub yaml: AsyncTask<ResourceKey, serde_json::Value>,
+    /// Object + events fetch backing the describe view.
+    pub describe: AsyncTask<ResourceKey, crate::kube::fetch::DescribeData>,
+    /// Ownership-chain trace backing the trace view.
+    pub trace: AsyncTask<ResourceKey, crate::trace::TraceResult>,
+    /// Relationship graph backing the graph view.
+    pub graph: AsyncTask<ResourceKey, crate::trace::ResourceGraph>,
 
-    // Describe fetch
-    pub describe_fetch_pending: Option<String>,
-    pub describe_fetched: Option<serde_json::Value>,
-    pub describe_fetch_rx:
-        Option<tokio::sync::oneshot::Receiver<anyhow::Result<serde_json::Value>>>,
-
-    // Trace
-    pub trace_pending: Option<ResourceKey>,
-    pub trace_result: Option<crate::trace::TraceResult>,
-    pub trace_result_rx:
-        Option<tokio::sync::oneshot::Receiver<anyhow::Result<crate::trace::TraceResult>>>,
-
-    // Graph
-    pub graph_pending: Option<ResourceKey>,
-    pub graph_result: Option<crate::trace::ResourceGraph>,
-    pub graph_result_rx:
-        Option<tokio::sync::oneshot::Receiver<anyhow::Result<crate::trace::ResourceGraph>>>,
-
-    // Operations (suspend, resume, etc.)
-    pub pending_operation: Option<PendingOperation>,
-    pub operation_result_rx: Option<tokio::sync::oneshot::Receiver<anyhow::Result<()>>>,
+    /// Mutating operation (suspend, resume, reconcile, delete). The result
+    /// payload is `()`; success/failure feeds the status message.
+    pub operation: AsyncTask<PendingOperation, ()>,
+    /// Keybinding of the last dispatched operation, for the success message.
     pub last_operation_key: Option<char>,
+    /// Operation waiting for the user's confirmation dialog.
     pub confirmation_pending: Option<PendingOperation>,
 }
 
 impl AsyncOperationState {
     pub fn clear_pending(&mut self) {
-        self.yaml_fetch_pending = None;
-        self.yaml_fetched = None;
-        self.yaml_fetch_rx = None;
-
-        self.describe_fetch_pending = None;
-        self.describe_fetched = None;
-        self.describe_fetch_rx = None;
-
-        self.trace_pending = None;
-        self.trace_result = None;
-        self.trace_result_rx = None;
-
-        self.graph_pending = None;
-        self.graph_result = None;
-        self.graph_result_rx = None;
-
-        self.pending_operation = None;
-        self.operation_result_rx = None;
+        self.yaml.clear();
+        self.describe.clear();
+        self.trace.clear();
+        self.graph.clear();
+        self.operation.clear();
         self.last_operation_key = None;
         self.confirmation_pending = None;
     }
@@ -442,9 +422,121 @@ impl ControllerPodState {
     }
 }
 
+/// Bounded store for the live Kubernetes events feed.
+///
+/// Events are deduplicated by UID (the API server aggregates repeat
+/// occurrences into one Event object with a rising `count`), and the store
+/// evicts the oldest-seen entries past [`crate::constants::MAX_KUBE_EVENTS`].
+#[derive(Debug, Default)]
+pub struct KubeEventStore {
+    events: std::collections::HashMap<String, crate::kube::events::KubeEventInfo>,
+}
+
+impl KubeEventStore {
+    /// Insert or update an event by UID, evicting the oldest-seen entry when
+    /// the store is over capacity.
+    pub fn upsert(&mut self, info: crate::kube::events::KubeEventInfo) {
+        self.events.insert(info.uid.clone(), info);
+        while self.events.len() > crate::constants::MAX_KUBE_EVENTS {
+            let oldest_uid = self
+                .events
+                .values()
+                .min_by_key(|event| event.last_seen)
+                .map(|event| event.uid.clone());
+            match oldest_uid {
+                Some(uid) => {
+                    self.events.remove(&uid);
+                }
+                None => break,
+            }
+        }
+    }
+
+    /// Remove an event (deleted on the cluster, usually TTL expiry).
+    pub fn remove(&mut self, uid: &str) {
+        self.events.remove(uid);
+    }
+
+    /// All events, newest last-seen first.
+    pub fn sorted_events(&self) -> Vec<&crate::kube::events::KubeEventInfo> {
+        let mut events: Vec<_> = self.events.values().collect();
+        events.sort_by(|a, b| b.last_seen.cmp(&a.last_seen).then(a.uid.cmp(&b.uid)));
+        events
+    }
+
+    pub fn len(&self) -> usize {
+        self.events.len()
+    }
+
+    #[allow(dead_code)] // Used in tests
+    pub fn is_empty(&self) -> bool {
+        self.events.is_empty()
+    }
+
+    /// Drop all events (e.g. on namespace or context switch — the restarted
+    /// watcher re-lists the events in scope).
+    pub fn clear(&mut self) {
+        self.events.clear();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn make_event(uid: &str, seconds_ago: i64) -> crate::kube::events::KubeEventInfo {
+        crate::kube::events::KubeEventInfo::from_json(&serde_json::json!({
+            "metadata": {
+                "uid": uid,
+                "namespace": "flux-system",
+            },
+            "involvedObject": {"kind": "Kustomization", "name": uid},
+            "type": "Normal",
+            "reason": "Test",
+            "message": "test event",
+            "lastTimestamp": (chrono::Utc::now() - chrono::Duration::seconds(seconds_ago))
+                .to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        }))
+        .expect("test event should parse")
+    }
+
+    #[test]
+    fn kube_event_store_dedups_by_uid_and_sorts_newest_first() {
+        let mut store = KubeEventStore::default();
+        store.upsert(make_event("older", 120));
+        store.upsert(make_event("newer", 10));
+        // Same UID again — an update, not a new entry
+        store.upsert(make_event("older", 60));
+
+        assert_eq!(store.len(), 2);
+        let sorted = store.sorted_events();
+        assert_eq!(sorted[0].uid, "newer");
+        assert_eq!(sorted[1].uid, "older");
+
+        store.remove("newer");
+        assert_eq!(store.len(), 1);
+        store.clear();
+        assert!(store.is_empty());
+    }
+
+    #[test]
+    fn kube_event_store_evicts_oldest_past_cap() {
+        let mut store = KubeEventStore::default();
+        for i in 0..crate::constants::MAX_KUBE_EVENTS {
+            store.upsert(make_event(&format!("uid-{i}"), 1000 + i as i64));
+        }
+        assert_eq!(store.len(), crate::constants::MAX_KUBE_EVENTS);
+
+        // One more (newest) evicts the oldest-seen entry, not the new one
+        store.upsert(make_event("newest", 0));
+        assert_eq!(store.len(), crate::constants::MAX_KUBE_EVENTS);
+        assert_eq!(store.sorted_events()[0].uid, "newest");
+        let oldest_uid = format!("uid-{}", crate::constants::MAX_KUBE_EVENTS - 1);
+        assert!(
+            !store.sorted_events().iter().any(|e| e.uid == oldest_uid),
+            "oldest-seen event should have been evicted"
+        );
+    }
 
     #[test]
     fn view_classifiers_partition_views_as_expected() {
@@ -470,6 +562,17 @@ mod tests {
         }
         assert!(!View::ResourceList.is_nested_view());
         assert!(!View::ResourceFavorites.is_nested_view());
+
+        // The events feed is a root-level view with selection-based
+        // navigation: not nested, not a resource list, no line scroll.
+        assert!(!View::EventList.is_nested_view());
+        assert!(!View::EventList.is_list_view());
+        assert!(!View::EventList.is_text_search_view());
+        assert!(
+            View::EventList
+                .scroll_offset_mut(&mut ViewState::default())
+                .is_none()
+        );
     }
 
     #[test]

--- a/src/tui/commands.rs
+++ b/src/tui/commands.rs
@@ -18,6 +18,10 @@ pub struct Command {
 /// Application commands (non-CRD commands)
 pub const APP_COMMANDS: &[Command] = &[
     Command {
+        name: "events",
+        takes_args: false,
+    },
+    Command {
         name: "healthy",
         takes_args: false,
     },
@@ -133,6 +137,12 @@ pub fn find_matching_commands(prefix: &str) -> Vec<String> {
 }
 
 // Command matching helpers - use these instead of hardcoding command strings
+
+/// Check if command opens the live Kubernetes events view
+pub fn is_events_command(cmd: &str) -> bool {
+    let cmd_lower = cmd.to_lowercase();
+    cmd_lower == "events" || cmd_lower == "event" || cmd_lower == "ev"
+}
 
 /// Check if command is readonly (handles both "readonly" and "read-only")
 pub fn is_readonly_command(cmd: &str) -> bool {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -29,9 +29,8 @@ use ratatui::{Terminal, backend::CrosstermBackend};
 use std::io;
 
 use crate::models::FluxResourceKind;
-use crate::watcher::ResourceKey;
 
-pub use crate::kube::fetch::{fetch_resource, fetch_resource_yaml};
+pub use crate::kube::fetch::fetch_resource_yaml;
 
 /// Extract Flux bundle version from deployment metadata labels
 /// Returns the app.kubernetes.io/version label if present (e.g., "v2.7.5")
@@ -375,229 +374,130 @@ pub async fn run_tui_with_async_init(
 
             terminal.draw(|f| app.render(f))?;
 
-            // Check if we need to fetch YAML asynchronously
-            // Only if Kubernetes is initialized
+            // Dispatch queued view fetches (YAML, describe, trace, graph).
+            // Each spawned task reports back through its AsyncTask channel.
             if kube_initialized {
-                if let Some((key, client, tx)) = app.trigger_yaml_fetch() {
-                    // Parse key using type-safe ResourceKey
-                    if let Some(rk) = ResourceKey::parse(&key) {
-                        tracing::debug!(
-                            "Fetching YAML for {}/{} in namespace {}",
-                            rk.resource_type,
-                            rk.name,
-                            rk.namespace
-                        );
-
-                        // Spawn async task to fetch resource
-                        let client_clone = client.clone();
+                if let Some(client) = app.kube_client.clone() {
+                    if let Some((rk, tx)) = app.async_state.yaml.dispatch() {
+                        let client = client.clone();
                         tokio::spawn(async move {
+                            tracing::debug!("Fetching YAML for {}", rk);
                             let result = fetch_resource_yaml(
-                                &client_clone,
+                                &client,
                                 &rk.resource_type,
                                 &rk.namespace,
                                 &rk.name,
                             )
                             .await;
                             if let Err(ref e) = result {
-                                tracing::warn!(
-                                    "Failed to fetch YAML for {}/{} in namespace {}: {}",
-                                    rk.resource_type,
-                                    rk.name,
-                                    rk.namespace,
-                                    e
-                                );
-                            } else {
-                                tracing::debug!(
-                                    "Successfully fetched YAML for {}/{}",
-                                    rk.resource_type,
-                                    rk.name
-                                );
+                                tracing::warn!("Failed to fetch YAML for {}: {}", rk, e);
                             }
                             let _ = tx.send(result);
                         });
-                    } else {
-                        tracing::error!("Failed to parse resource key for YAML fetch: {}", key);
-                        let _ =
-                            tx.send(Err(anyhow::anyhow!("Invalid resource key format: {}", key)));
                     }
-                }
-            }
 
-            // Check if we need to fetch describe data asynchronously
-            if kube_initialized {
-                if let Some((key, client, tx)) = app.trigger_describe_fetch() {
-                    if let Some(rk) = ResourceKey::parse(&key) {
-                        tracing::debug!(
-                            "Fetching describe data for {}/{} in namespace {}",
-                            rk.resource_type,
-                            rk.name,
-                            rk.namespace
-                        );
-
-                        let client_clone = client.clone();
+                    if let Some((rk, tx)) = app.async_state.describe.dispatch() {
+                        let client = client.clone();
                         tokio::spawn(async move {
-                            let result = fetch_resource(
-                                &client_clone,
+                            tracing::debug!("Fetching describe data for {}", rk);
+                            let result = crate::kube::fetch::fetch_describe_data(
+                                &client,
                                 &rk.resource_type,
                                 &rk.namespace,
                                 &rk.name,
                             )
                             .await;
                             if let Err(ref e) = result {
-                                tracing::warn!(
-                                    "Failed to fetch describe data for {}/{} in namespace {}: {}",
-                                    rk.resource_type,
-                                    rk.name,
-                                    rk.namespace,
-                                    e
-                                );
-                            } else {
-                                tracing::debug!(
-                                    "Successfully fetched describe data for {}/{}",
-                                    rk.resource_type,
-                                    rk.name
-                                );
+                                tracing::warn!("Failed to fetch describe data for {}: {}", rk, e);
                             }
                             let _ = tx.send(result);
                         });
-                    } else {
-                        tracing::error!("Failed to parse resource key for describe fetch: {}", key);
-                        let _ =
-                            tx.send(Err(anyhow::anyhow!("Invalid resource key format: {}", key)));
                     }
-                }
-            }
 
-            // Check if we need to trace a resource asynchronously
-            // Only if Kubernetes is initialized
-            if kube_initialized {
-                if let Some(req) = app.trigger_trace() {
-                    tracing::debug!(
-                        "Tracing {}/{} in namespace {}",
-                        req.resource_type,
-                        req.name,
-                        req.namespace
-                    );
-
-                    // Spawn async task to trace resource
-                    let client_clone = req.client.clone();
-                    let resource_type = req.resource_type;
-                    let namespace = req.namespace;
-                    let name = req.name;
-                    let tx = req.tx;
-                    tokio::spawn(async move {
-                        use crate::tui::trace;
-                        let result =
-                            trace::trace_object(&client_clone, &resource_type, &namespace, &name)
-                                .await;
-                        match result {
-                            Ok(trace_result) => {
-                                tracing::debug!(
-                                    "Successfully traced {}/{} in namespace {}",
-                                    resource_type,
-                                    name,
-                                    namespace
-                                );
-                                let _ = tx.send(Ok(trace_result));
+                    if let Some((rk, tx)) = app.async_state.trace.dispatch() {
+                        let client = client.clone();
+                        tokio::spawn(async move {
+                            tracing::debug!("Tracing {}", rk);
+                            let result = crate::tui::trace::trace_object(
+                                &client,
+                                &rk.resource_type,
+                                &rk.namespace,
+                                &rk.name,
+                            )
+                            .await;
+                            if let Err(ref e) = result {
+                                tracing::warn!("Failed to trace {}: {}", rk, e);
                             }
-                            Err(e) => {
-                                tracing::warn!(
-                                    "Failed to trace {}/{} in namespace {}: {}",
-                                    resource_type,
-                                    name,
-                                    namespace,
-                                    e
-                                );
-                                let _ = tx.send(Err(anyhow::anyhow!(
-                                    "Trace failed for {}/{} in {}: {}",
-                                    resource_type,
-                                    name,
-                                    namespace,
-                                    e
-                                )));
+                            let _ = tx.send(result);
+                        });
+                    }
+
+                    if let Some((rk, tx)) = app.async_state.graph.dispatch() {
+                        let client = client.clone();
+                        tokio::spawn(async move {
+                            tracing::debug!("Building graph for {}", rk);
+                            let result = crate::trace::build_resource_graph(
+                                &client,
+                                &rk.resource_type,
+                                &rk.namespace,
+                                &rk.name,
+                            )
+                            .await;
+                            if let Err(ref e) = result {
+                                tracing::warn!("Failed to build graph for {}: {}", rk, e);
                             }
-                        }
-                    });
+                            let _ = tx.send(result);
+                        });
+                    }
                 }
             }
 
-            // Check for trace results
-            if let Some(result) = app.try_get_trace_result() {
+            // Poll fetch results and store them for the views.
+            if let Some(result) = app.async_state.yaml.try_recv() {
                 match result {
-                    Ok(trace_result) => {
-                        app.set_trace_result(trace_result);
-                        // Switch to trace view - use public method if available
-                        // For now, we'll set it via a method we need to add
-                        app.set_view_trace();
-                    }
+                    Ok(yaml) => app.async_state.yaml.set_result(yaml),
                     Err(e) => {
-                        app.set_trace_error();
-                        app.set_status_message((format!("Trace failed: {}", e), true));
-                    }
-                }
-            }
-
-            // Check if we need to build graph asynchronously
-            if kube_initialized {
-                if let Some((rk, client, tx)) = app.trigger_graph() {
-                    tracing::debug!(
-                        "Building graph for {}/{} in namespace {}",
-                        rk.resource_type,
-                        rk.name,
-                        rk.namespace
-                    );
-                    tokio::spawn(async move {
-                        use crate::trace::build_resource_graph;
-                        let result = build_resource_graph(
-                            &client,
-                            &rk.resource_type,
-                            &rk.namespace,
-                            &rk.name,
-                        )
-                        .await;
-                        let _ = tx.send(result);
-                    });
-                }
-            }
-
-            // Check for graph building result
-            if let Some(result) = app.try_get_graph_result() {
-                match result {
-                    Ok(graph_result) => {
-                        app.set_graph_result(graph_result);
-                        // Graph view is already set, just update the result
-                    }
-                    Err(e) => {
-                        app.set_graph_error();
-                        app.set_status_message((format!("Graph building failed: {}", e), true));
-                        // Return to previous view on error - use public method
-                        app.set_view(app.previous_list_view());
-                    }
-                }
-            }
-
-            // Check for YAML fetch results
-            if let Some(result) = app.try_get_yaml_result() {
-                match result {
-                    Ok(yaml) => app.set_yaml_fetched(yaml),
-                    Err(e) => {
-                        tracing::debug!("YAML fetch error result received: {}", e);
-                        app.set_yaml_fetch_error();
+                        app.async_state.yaml.set_error();
                         app.set_status_message((format!("Failed to fetch YAML: {}", e), true));
                     }
                 }
             }
 
-            // Check for describe fetch results
-            if let Some(result) = app.try_get_describe_result() {
+            if let Some(result) = app.async_state.describe.try_recv() {
                 match result {
-                    Ok(describe) => app.set_describe_fetched(describe),
+                    Ok(describe) => app.async_state.describe.set_result(describe),
                     Err(e) => {
-                        app.set_describe_fetch_error();
+                        app.async_state.describe.set_error();
                         app.set_status_message((
                             format!("Failed to fetch description: {}", e),
                             true,
                         ));
+                    }
+                }
+            }
+
+            if let Some(result) = app.async_state.trace.try_recv() {
+                match result {
+                    Ok(trace_result) => {
+                        app.async_state.trace.set_result(trace_result);
+                        app.set_view_trace();
+                    }
+                    Err(e) => {
+                        app.async_state.trace.set_error();
+                        app.set_status_message((format!("Trace failed: {}", e), true));
+                    }
+                }
+            }
+
+            if let Some(result) = app.async_state.graph.try_recv() {
+                match result {
+                    // set_graph_result also places keyboard focus on the object node
+                    Ok(graph_result) => app.set_graph_result(graph_result),
+                    Err(e) => {
+                        app.async_state.graph.set_error();
+                        app.set_status_message((format!("Graph building failed: {}", e), true));
+                        // Return to the previous view instead of an empty graph
+                        app.set_view(app.previous_list_view());
                     }
                 }
             }
@@ -930,6 +830,16 @@ pub async fn run_tui_with_async_init(
                         crate::watcher::WatchEvent::DeploymentApplied(deployment_json) => {
                             let version = extract_flux_bundle_version(&deployment_json);
                             app.controller_pods.set_flux_bundle_version(version);
+                        }
+                        crate::watcher::WatchEvent::KubeEventApplied(event_json) => {
+                            if let Some(info) =
+                                crate::kube::events::KubeEventInfo::from_json(&event_json)
+                            {
+                                app.kube_events.upsert(info);
+                            }
+                        }
+                        crate::watcher::WatchEvent::KubeEventDeleted(uid) => {
+                            app.kube_events.remove(&uid);
                         }
                     }
                 }

--- a/src/tui/views/describe.rs
+++ b/src/tui/views/describe.rs
@@ -109,9 +109,77 @@ fn push_value_lines(lines: &mut Vec<Line<'static>>, value: &Value, indent: usize
     }
 }
 
+/// Append the kubectl-style Events section.
+///
+/// `events` is `None` when rendering from the locally cached object (no
+/// events were fetched) — the section is omitted entirely rather than
+/// claiming the resource has none.
+fn push_events_section(
+    lines: &mut Vec<Line<'static>>,
+    events: &[crate::kube::events::KubeEventInfo],
+    events_error: Option<&str>,
+    theme: &Theme,
+) {
+    push_section_header(lines, "Events", theme);
+
+    if let Some(error) = events_error {
+        lines.push(Line::from(Span::styled(
+            format!("  Events unavailable: {}", error),
+            Style::default().fg(theme.text_secondary),
+        )));
+        return;
+    }
+    if events.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  <none>".to_string(),
+            Style::default().fg(theme.text_secondary),
+        )));
+        return;
+    }
+
+    lines.push(Line::from(Span::styled(
+        format!(
+            "  {:<8} {:<26} {:>8} {:>6}  {:<24} {}",
+            "TYPE", "REASON", "AGE", "COUNT", "FROM", "MESSAGE"
+        ),
+        Style::default().fg(theme.text_label),
+    )));
+    for event in events {
+        let row_style = if event.is_warning() {
+            Style::default().fg(theme.status_error)
+        } else {
+            Style::default()
+        };
+        let age = crate::tui::views::helpers::format_age(event.last_seen);
+        // Multi-line messages (common for apply errors) continue on
+        // indented follow-up lines so nothing is lost.
+        let mut message_lines = event.message.lines();
+        let first_message = message_lines.next().unwrap_or_default();
+        lines.push(Line::from(Span::styled(
+            format!(
+                "  {:<8} {:<26} {:>8} {:>6}  {:<24} {}",
+                event.event_type,
+                event.reason,
+                age,
+                format!("x{}", event.count),
+                event.source,
+                first_message,
+            ),
+            row_style,
+        )));
+        for continuation in message_lines {
+            lines.push(Line::from(Span::styled(
+                format!("  {:<78} {}", "", continuation),
+                row_style,
+            )));
+        }
+    }
+}
+
 fn build_describe_lines(
     resource: Option<&crate::watcher::ResourceInfo>,
     obj_json: &Value,
+    events: Option<(&[crate::kube::events::KubeEventInfo], Option<&str>)>,
     theme: &Theme,
 ) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
@@ -211,6 +279,10 @@ fn build_describe_lines(
         push_value_lines(&mut lines, status, 2, theme);
     }
 
+    if let Some((events, events_error)) = events {
+        push_events_section(&mut lines, events, events_error, theme);
+    }
+
     lines
 }
 
@@ -221,8 +293,8 @@ pub fn render_resource_describe(
     selected_resource_key: &Option<String>,
     state: &ResourceState,
     resource_objects: &HashMap<String, serde_json::Value>,
-    describe_fetched: &Option<serde_json::Value>,
-    describe_fetch_pending: &Option<String>,
+    describe_fetched: Option<&crate::kube::fetch::DescribeData>,
+    describe_loading: bool,
     describe_scroll_offset: &mut usize,
     search: &mut TextSearchState,
     theme: &Theme,
@@ -242,9 +314,14 @@ pub fn render_resource_describe(
         }
     };
 
-    let obj_json = if let Some(fetched) = describe_fetched {
-        fetched.clone()
-    } else if describe_fetch_pending.is_some() {
+    // Events only exist on the fetched path; the locally cached fallback
+    // object omits the section rather than claiming there are none.
+    let (obj_json, events) = if let Some(fetched) = describe_fetched {
+        (
+            fetched.object.clone(),
+            Some((fetched.events.as_slice(), fetched.events_error.as_deref())),
+        )
+    } else if describe_loading {
         crate::tui::views::helpers::render_loading_state(
             f,
             area,
@@ -255,7 +332,7 @@ pub fn render_resource_describe(
         return;
     } else {
         match resource_objects.get(key).cloned() {
-            Some(obj) => obj,
+            Some(obj) => (obj, None),
             None => {
                 crate::tui::views::helpers::render_empty_state(
                     f,
@@ -278,7 +355,7 @@ pub fn render_resource_describe(
         "Describe".to_string()
     };
 
-    let all_lines = build_describe_lines(resource.as_ref(), &cleaned_json, theme);
+    let all_lines = build_describe_lines(resource.as_ref(), &cleaned_json, events, theme);
     let visible_height = area.height.saturating_sub(2) as usize;
 
     // Text search: match against the plain-text content of each line
@@ -321,4 +398,94 @@ pub fn render_resource_describe(
         .block(block)
         .wrap(Wrap { trim: false });
     f.render_widget(paragraph, area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kube::events::KubeEventInfo;
+
+    fn line_text(line: &Line<'_>) -> String {
+        line.spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect()
+    }
+
+    fn section_lines(events: &[KubeEventInfo], error: Option<&str>) -> Vec<String> {
+        let mut lines = Vec::new();
+        push_events_section(&mut lines, events, error, &Theme::default());
+        lines.iter().map(line_text).collect()
+    }
+
+    fn sample_event(event_type: &str, message: &str) -> KubeEventInfo {
+        KubeEventInfo::from_json(&serde_json::json!({
+            "metadata": {"uid": "uid-1", "namespace": "flux-system"},
+            "involvedObject": {
+                "kind": "Kustomization",
+                "namespace": "flux-system",
+                "name": "podinfo"
+            },
+            "type": event_type,
+            "reason": "TestReason",
+            "message": message,
+            "count": 2,
+            "source": {"component": "kustomize-controller"}
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn events_section_renders_header_and_rows() {
+        let lines = section_lines(&[sample_event("Warning", "something failed")], None);
+        // Section title, column header, one event row
+        assert!(lines.iter().any(|l| l.trim() == "Events"));
+        let header = lines.iter().find(|l| l.contains("REASON")).unwrap();
+        assert!(header.contains("TYPE") && header.contains("MESSAGE"));
+        let row = lines.iter().find(|l| l.contains("TestReason")).unwrap();
+        assert!(row.contains("Warning"));
+        assert!(row.contains("x2"));
+        assert!(row.contains("kustomize-controller"));
+        assert!(row.contains("something failed"));
+    }
+
+    #[test]
+    fn events_section_multiline_message_continues_indented() {
+        let lines = section_lines(&[sample_event("Normal", "line one\nline two")], None);
+        let row_idx = lines.iter().position(|l| l.contains("line one")).unwrap();
+        assert!(lines[row_idx + 1].contains("line two"));
+        assert!(!lines[row_idx + 1].contains("TestReason"));
+    }
+
+    #[test]
+    fn events_section_empty_and_error_states() {
+        assert!(
+            section_lines(&[], None)
+                .iter()
+                .any(|l| l.contains("<none>"))
+        );
+        let errored = section_lines(&[], Some("forbidden"));
+        assert!(
+            errored
+                .iter()
+                .any(|l| l.contains("Events unavailable: forbidden"))
+        );
+    }
+
+    #[test]
+    fn describe_lines_include_events_only_when_fetched() {
+        let obj = serde_json::json!({
+            "apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+            "kind": "Kustomization",
+            "metadata": {"name": "podinfo", "namespace": "flux-system"}
+        });
+        let theme = Theme::default();
+
+        let without = build_describe_lines(None, &obj, None, &theme);
+        assert!(!without.iter().map(line_text).any(|l| l.trim() == "Events"));
+
+        let events = [sample_event("Normal", "ok")];
+        let with = build_describe_lines(None, &obj, Some((&events, None)), &theme);
+        assert!(with.iter().map(line_text).any(|l| l.trim() == "Events"));
+    }
 }

--- a/src/tui/views/events.rs
+++ b/src/tui/views/events.rs
@@ -1,0 +1,217 @@
+//! Live Kubernetes events view rendering
+//!
+//! Renders the `:events` feed: a table of core/v1 Events in the current
+//! namespace scope, newest first, with Warnings highlighted. The feed is
+//! populated by the lazily started events watcher.
+
+use crate::kube::events::KubeEventInfo;
+use crate::tui::theme::Theme;
+use ratatui::{
+    Frame,
+    layout::{Constraint, Rect},
+    style::{Modifier, Style},
+    widgets::{Row, Table},
+};
+use std::cmp;
+
+/// Render the Kubernetes events table.
+///
+/// `events` is pre-filtered and sorted newest-first; `total_count` is the
+/// unfiltered feed size (shown in the title so an active filter is visible).
+pub fn render_kube_events(
+    f: &mut Frame,
+    area: Rect,
+    events: &[KubeEventInfo],
+    total_count: usize,
+    selected_index: usize,
+    scroll_offset: &mut usize,
+    filter: &str,
+    all_namespaces: bool,
+    theme: &Theme,
+) {
+    let visible_height = (area.height as usize).saturating_sub(2);
+    const SCROLL_BUFFER: usize = 2; // Keep 2 rows buffer before scrolling
+
+    crate::tui::views::helpers::update_scroll_offset(
+        selected_index,
+        visible_height,
+        scroll_offset,
+        SCROLL_BUFFER,
+    );
+
+    let mut title = if filter.is_empty() {
+        format!("Events ({})", total_count)
+    } else {
+        format!("Events ({}/{}) /{}", events.len(), total_count, filter)
+    };
+
+    if events.is_empty() {
+        let (message, hint) = if filter.is_empty() {
+            (
+                "No events yet",
+                "Waiting for events in the current namespace scope...",
+            )
+        } else {
+            ("No events match the filter", "Press / to change the filter")
+        };
+        crate::tui::views::helpers::render_empty_state(f, area, &title, message, hint, theme);
+        return;
+    }
+
+    let valid_selected = cmp::min(selected_index, events.len().saturating_sub(1));
+
+    let mut header_cells = vec!["LAST SEEN", "TYPE", "REASON"];
+    if all_namespaces {
+        header_cells.push("NAMESPACE");
+    }
+    header_cells.extend(["OBJECT", "COUNT", "FROM", "MESSAGE"]);
+    let header = Row::new(header_cells).style(
+        Style::default()
+            .fg(theme.table_header)
+            .add_modifier(Modifier::BOLD),
+    );
+
+    let rows: Vec<Row> = events
+        .iter()
+        .skip(*scroll_offset)
+        .take(visible_height)
+        .enumerate()
+        .map(|(idx, event)| {
+            let actual_idx = *scroll_offset + idx;
+            let style = if actual_idx == valid_selected {
+                theme.table_selected_style()
+            } else if event.is_warning() {
+                Style::default().fg(theme.status_error)
+            } else {
+                Style::default().fg(theme.text_primary)
+            };
+
+            let mut cells = vec![
+                crate::tui::views::helpers::format_age(event.last_seen),
+                event.event_type.clone(),
+                event.reason.clone(),
+            ];
+            if all_namespaces {
+                cells.push(event.involved_namespace.clone());
+            }
+            cells.extend([
+                event.object_label(),
+                format!("x{}", event.count),
+                event.source.clone(),
+                // Single row per event: collapse multi-line messages
+                event.message.replace('\n', " "),
+            ]);
+            Row::new(cells).style(style)
+        })
+        .collect();
+
+    let mut constraints = vec![
+        Constraint::Length(9),  // LAST SEEN
+        Constraint::Length(8),  // TYPE
+        Constraint::Length(24), // REASON
+    ];
+    if all_namespaces {
+        constraints.push(Constraint::Length(16)); // NAMESPACE
+    }
+    constraints.extend([
+        Constraint::Length(32), // OBJECT
+        Constraint::Length(6),  // COUNT
+        Constraint::Length(22), // FROM
+        Constraint::Min(20),    // MESSAGE
+    ]);
+
+    // Scroll position indicator, matching the resource list style
+    if events.len() > visible_height {
+        let first = *scroll_offset + 1;
+        let last = cmp::min(*scroll_offset + visible_height, events.len());
+        title = format!("{} [{}-{}]", title, first, last);
+    }
+
+    let block = crate::tui::views::helpers::create_themed_block(&title, theme);
+    let table = Table::new(rows, constraints).header(header).block(block);
+    f.render_widget(table, area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    fn make_event(uid: &str, event_type: &str, reason: &str) -> KubeEventInfo {
+        KubeEventInfo::from_json(&serde_json::json!({
+            "metadata": {"uid": uid, "namespace": "flux-system"},
+            "involvedObject": {
+                "kind": "Kustomization",
+                "namespace": "flux-system",
+                "name": "podinfo"
+            },
+            "type": event_type,
+            "reason": reason,
+            "message": "line one\nline two",
+            "count": 2,
+            "lastTimestamp": "2026-07-01T12:30:00Z",
+            "source": {"component": "kustomize-controller"}
+        }))
+        .unwrap()
+    }
+
+    fn render_to_text(events: &[KubeEventInfo], all_namespaces: bool) -> String {
+        let mut terminal = Terminal::new(TestBackend::new(160, 12)).unwrap();
+        let mut scroll_offset = 0;
+        terminal
+            .draw(|frame| {
+                render_kube_events(
+                    frame,
+                    frame.area(),
+                    events,
+                    events.len(),
+                    0,
+                    &mut scroll_offset,
+                    "",
+                    all_namespaces,
+                    &Theme::default(),
+                );
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let mut text = String::new();
+        for y in 0..buffer.area.height {
+            for x in 0..buffer.area.width {
+                text.push_str(buffer[(x, y)].symbol());
+            }
+            text.push('\n');
+        }
+        text
+    }
+
+    #[test]
+    fn renders_event_rows_and_columns() {
+        let events = [
+            make_event("a", "Warning", "ReconciliationFailed"),
+            make_event("b", "Normal", "ReconciliationSucceeded"),
+        ];
+        let text = render_to_text(&events, false);
+        assert!(text.contains("REASON"));
+        assert!(!text.contains("NAMESPACE"), "namespaced scope hides column");
+        assert!(text.contains("ReconciliationFailed"));
+        assert!(text.contains("Kustomization/podinfo"));
+        assert!(text.contains("x2"));
+        assert!(text.contains("line one line two"), "message is one row");
+        assert!(text.contains("Events (2)"));
+    }
+
+    #[test]
+    fn all_namespaces_scope_adds_namespace_column() {
+        let events = [make_event("a", "Normal", "Sync")];
+        let text = render_to_text(&events, true);
+        assert!(text.contains("NAMESPACE"));
+        assert!(text.contains("flux-system"));
+    }
+
+    #[test]
+    fn empty_feed_renders_waiting_state() {
+        let text = render_to_text(&[], false);
+        assert!(text.contains("No events yet"));
+    }
+}

--- a/src/tui/views/graph.rs
+++ b/src/tui/views/graph.rs
@@ -5,7 +5,6 @@
 
 use crate::trace::{NodeType, RelationshipType, ResourceGraph};
 use crate::tui::theme::Theme;
-use crate::watcher::ResourceKey;
 use ratatui::{
     Frame,
     layout::{Margin, Rect},
@@ -19,8 +18,8 @@ pub fn render_resource_graph(
     f: &mut Frame,
     area: Rect,
     _selected_resource_key: &Option<String>,
-    graph_result: &Option<ResourceGraph>,
-    graph_pending: &Option<ResourceKey>,
+    graph_result: Option<&ResourceGraph>,
+    graph_loading: bool,
     scroll_offset: &mut usize,  // Line-based scroll offset (like YAML view)
     focus_index: Option<usize>, // Index of the keyboard-focused node, if any
     theme: &Theme,
@@ -28,7 +27,7 @@ pub fn render_resource_graph(
     let outer_block = crate::tui::views::helpers::create_themed_block("Resource Graph", theme);
 
     // Show loading if pending OR if no result yet (prevents flashing "no data" message)
-    if graph_pending.is_some() || graph_result.is_none() {
+    if graph_loading || graph_result.is_none() {
         crate::tui::views::helpers::render_loading_state(
             f,
             area,

--- a/src/tui/views/help.rs
+++ b/src/tui/views/help.rs
@@ -55,6 +55,7 @@ pub fn render_help(f: &mut Frame, area: Rect, theme: &Theme, namespace_hotkeys: 
         (":unhealthy", "Show unhealthy resources"),
         (":favorites", "View favorites"),
         (":fav", "View favorites"),
+        (":events", "Live Kubernetes events feed"),
         (":q", "Quit application"),
     ];
     render_help_column(f, column_chunks[1], "GENERAL", &general_items, theme);

--- a/src/tui/views/mod.rs
+++ b/src/tui/views/mod.rs
@@ -8,6 +8,7 @@ mod confirmation;
 mod connection_error;
 mod describe;
 mod detail;
+mod events;
 mod footer;
 mod graph;
 mod header;
@@ -26,6 +27,7 @@ pub use confirmation::*;
 pub use connection_error::render_connection_error;
 pub use describe::*;
 pub use detail::*;
+pub use events::*;
 // favorites module is not exported - favorites view uses render_resource_list instead
 pub use footer::*;
 pub use graph::*;

--- a/src/tui/views/trace.rs
+++ b/src/tui/views/trace.rs
@@ -4,7 +4,6 @@ use crate::tui::app::state::TextSearchState;
 use crate::tui::theme::Theme;
 use crate::tui::trace::{TraceNode, TraceResult};
 use crate::tui::views::yaml::decorate_title_with_search;
-use crate::watcher::ResourceKey;
 use ratatui::{
     Frame,
     layout::Rect,
@@ -35,13 +34,13 @@ pub fn render_resource_trace(
     f: &mut Frame,
     area: Rect,
     _selected_resource_key: &Option<String>,
-    trace_result: &Option<TraceResult>,
-    trace_pending: &Option<ResourceKey>,
+    trace_result: Option<&TraceResult>,
+    trace_loading: bool,
     scroll_offset: &mut usize,
     search: &mut TextSearchState,
     theme: &Theme,
 ) {
-    if trace_pending.is_some() {
+    if trace_loading {
         crate::tui::views::helpers::render_loading_state(
             f,
             area,

--- a/src/tui/views/yaml.rs
+++ b/src/tui/views/yaml.rs
@@ -70,8 +70,8 @@ pub fn render_resource_yaml(
     selected_resource_key: &Option<String>,
     state: &ResourceState,
     resource_objects: &HashMap<String, serde_json::Value>,
-    yaml_fetched: &Option<serde_json::Value>,
-    yaml_fetch_pending: &Option<String>,
+    yaml_fetched: Option<&serde_json::Value>,
+    yaml_loading: bool,
     yaml_scroll_offset: &mut usize,
     search: &mut TextSearchState,
     theme: &Theme,
@@ -95,7 +95,7 @@ pub fn render_resource_yaml(
     let obj_json = if let Some(fetched) = yaml_fetched {
         // Use fetched YAML (complete)
         fetched.clone()
-    } else if yaml_fetch_pending.is_some() {
+    } else if yaml_loading {
         crate::tui::views::helpers::render_loading_state(
             f,
             area,

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -92,6 +92,10 @@ pub enum WatchEvent {
     PodDeleted(String), // pod_name
     /// Flux controller deployment was added or updated (for bundle version tracking)
     DeploymentApplied(serde_json::Value), // deployment_json
+    /// A Kubernetes Event (core/v1) was added or updated (events feed)
+    KubeEventApplied(serde_json::Value), // event_json
+    /// A Kubernetes Event was deleted (TTL expiry)
+    KubeEventDeleted(String), // event uid
 }
 
 /// Trait for watchable Flux resources
@@ -125,6 +129,11 @@ pub struct ResourceWatcher {
     controller_namespace: String,
     event_tx: mpsc::UnboundedSender<WatchEvent>,
     handles: Vec<JoinHandle<()>>,
+    /// The Kubernetes Events watcher has its own lifecycle: it is started
+    /// lazily (first time the events view opens) and can be stopped without
+    /// tearing down the resource watchers, since Events are the churniest
+    /// resource in a cluster and shouldn't be paid for while unused.
+    kube_events_handle: Option<JoinHandle<()>>,
 }
 
 impl ResourceWatcher {
@@ -145,6 +154,7 @@ impl ResourceWatcher {
                 controller_namespace,
                 event_tx: tx,
                 handles: Vec::new(),
+                kube_events_handle: None,
             },
             rx,
         )
@@ -165,14 +175,20 @@ impl ResourceWatcher {
             namespace
         );
 
-        // Stop existing watchers
+        // Stop existing watchers (remembering whether the lazily started
+        // events watcher was running so it survives the namespace switch)
+        let events_active = self.is_watching_kube_events();
         self.stop();
 
         // Update namespace
         self.current_namespace = namespace;
 
         // Restart all watchers with new namespace
-        self.watch_all()
+        self.watch_all()?;
+        if events_active {
+            self.watch_kube_events()?;
+        }
+        Ok(())
     }
 
     /// Start watching a specific resource type
@@ -735,6 +751,106 @@ impl ResourceWatcher {
         Ok(())
     }
 
+    /// Whether the Kubernetes Events watcher is currently running.
+    pub fn is_watching_kube_events(&self) -> bool {
+        self.kube_events_handle
+            .as_ref()
+            .is_some_and(|handle| !handle.is_finished())
+    }
+
+    /// Start watching Kubernetes Events (core/v1) in the current namespace
+    /// scope, feeding the events view. Started lazily — the first time the
+    /// events view opens — rather than in `watch_all`, because Events churn
+    /// far more than any other resource. A no-op if already running.
+    pub fn watch_kube_events(&mut self) -> Result<()> {
+        if self.is_watching_kube_events() {
+            return Ok(());
+        }
+
+        let client = self.client.clone();
+        let namespace = self.current_namespace.clone();
+        let event_tx = self.event_tx.clone();
+
+        let handle = tokio::spawn(async move {
+            use k8s_openapi::api::core::v1::Event as CoreEvent;
+
+            let api: Api<CoreEvent> = match namespace {
+                Some(ref ns) => Api::namespaced(client, ns),
+                None => Api::all(client),
+            };
+            let mut w =
+                Box::pin(watcher(api, watcher::Config::default()).backoff(CappedBackoff::new()));
+            let mut error_count = 0u32;
+
+            const WATCHER_NAME: &str = "Kubernetes events";
+            tracing::debug!("Starting Kubernetes events watcher");
+
+            while let Some(event) = w.next().await {
+                let ev = match event {
+                    Ok(ev) => ev,
+                    Err(e) => {
+                        if is_forbidden_error(&format!("{}", e)) {
+                            // RBAC denies access — retrying won't help, so stop rather
+                            // than flag the watch as degraded. Clear earlier degraded state.
+                            if error_count > 0 {
+                                let _ = event_tx
+                                    .send(WatchEvent::WatcherRecovered(WATCHER_NAME.to_string()));
+                            }
+                            let _ = event_tx.send(WatchEvent::Error(
+                                "Events watcher forbidden by RBAC".to_string(),
+                            ));
+                            tracing::info!("Events watcher forbidden by RBAC, stopping: {}", e);
+                            break;
+                        }
+                        error_count += 1;
+                        if error_count == 1 {
+                            let _ = event_tx
+                                .send(WatchEvent::WatcherDegraded(WATCHER_NAME.to_string()));
+                        }
+                        // Keep watching: backoff paces the retries.
+                        if error_count == 1 || error_count.is_multiple_of(10) {
+                            tracing::warn!("Events watcher error ({}): {}", error_count, e);
+                        }
+                        continue;
+                    }
+                };
+
+                // Init is excluded: it fires before the HTTP request succeeds
+                if error_count > 0 && !matches!(ev, watcher::Event::Init) {
+                    error_count = 0;
+                    let _ = event_tx.send(WatchEvent::WatcherRecovered(WATCHER_NAME.to_string()));
+                }
+
+                match ev {
+                    watcher::Event::InitApply(kube_event) | watcher::Event::Apply(kube_event) => {
+                        let event_json = serde_json::to_value(&kube_event).unwrap_or_default();
+                        let _ = event_tx.send(WatchEvent::KubeEventApplied(event_json));
+                    }
+                    watcher::Event::Delete(kube_event) => {
+                        if let Some(uid) = kube_event.metadata.uid {
+                            let _ = event_tx.send(WatchEvent::KubeEventDeleted(uid));
+                        }
+                    }
+                    watcher::Event::Init | watcher::Event::InitDone => {
+                        tracing::debug!("Kubernetes events watcher initialized");
+                    }
+                }
+            }
+        });
+
+        self.kube_events_handle = Some(handle);
+        Ok(())
+    }
+
+    /// Stop the Kubernetes Events watcher without touching the resource
+    /// watchers. A no-op if it isn't running.
+    pub fn stop_kube_events(&mut self) {
+        if let Some(handle) = self.kube_events_handle.take() {
+            tracing::debug!("Stopping Kubernetes events watcher");
+            handle.abort();
+        }
+    }
+
     /// Abort all watcher tasks
     pub fn stop(&mut self) {
         tracing::debug!("Stopping {} watchers", self.handles.len());
@@ -742,6 +858,7 @@ impl ResourceWatcher {
             handle.abort();
         }
         self.handles.clear();
+        self.stop_kube_events();
     }
 }
 

--- a/src/watcher/state.rs
+++ b/src/watcher/state.rs
@@ -54,8 +54,8 @@ impl ResourceKey {
         }
     }
 
-    /// Convert the ResourceKey back to its string representation (unused so far)
-    #[allow(dead_code)] // Used in tests
+    /// Convert the ResourceKey back to its string representation — the format
+    /// used by the resource state map and `selected_resource_key`.
     pub fn to_key_string(&self) -> String {
         format!("{}:{}:{}", self.resource_type, self.namespace, self.name)
     }

--- a/tests/snapshot_tests.rs
+++ b/tests/snapshot_tests.rs
@@ -562,6 +562,42 @@ fn test_render_resource_describe_with_data() {
         }
     });
 
+    // Include events so the snapshot covers the kubectl-style Events section
+    let describe_data = flux9s::kube::fetch::DescribeData {
+        object: resource_json,
+        events: vec![
+            flux9s::kube::events::KubeEventInfo::from_json(&serde_json::json!({
+                "metadata": {"uid": "uid-1", "namespace": "flux-system"},
+                "involvedObject": {
+                    "kind": "Kustomization",
+                    "namespace": "flux-system",
+                    "name": "my-kustomization"
+                },
+                "type": "Normal",
+                "reason": "ReconciliationSucceeded",
+                "message": "Reconciliation finished in 500ms",
+                "count": 3,
+                "source": {"component": "kustomize-controller"}
+            }))
+            .unwrap(),
+            flux9s::kube::events::KubeEventInfo::from_json(&serde_json::json!({
+                "metadata": {"uid": "uid-2", "namespace": "flux-system"},
+                "involvedObject": {
+                    "kind": "Kustomization",
+                    "namespace": "flux-system",
+                    "name": "my-kustomization"
+                },
+                "type": "Warning",
+                "reason": "HealthCheckFailed",
+                "message": "timeout waiting for deployment\nDeployment/podinfo status: 'InProgress'",
+                "count": 1,
+                "source": {"component": "kustomize-controller"}
+            }))
+            .unwrap(),
+        ],
+        events_error: None,
+    };
+
     let mut terminal = Terminal::new(TestBackend::new(120, 30)).unwrap();
     let mut describe_scroll_offset = 0;
 
@@ -575,8 +611,8 @@ fn test_render_resource_describe_with_data() {
                 &Some("Kustomization:flux-system:my-kustomization".to_string()),
                 &state,
                 &resource_objects,
-                &Some(resource_json),
-                &None,
+                Some(&describe_data),
+                false,
                 &mut describe_scroll_offset,
                 &mut TextSearchState::default(),
                 &theme,
@@ -605,8 +641,8 @@ fn test_render_resource_yaml_no_selection() {
                 &None,
                 &state,
                 &resource_objects,
-                &None,
-                &None,
+                None,
+                false,
                 &mut yaml_scroll_offset,
                 &mut TextSearchState::default(),
                 &theme,
@@ -635,8 +671,8 @@ fn test_render_resource_yaml_pending() {
                 &Some("Kustomization:flux-system:my-kustomization".to_string()),
                 &state,
                 &resource_objects,
-                &None,
-                &Some("Kustomization:flux-system:my-kustomization".to_string()),
+                None,
+                true,
                 &mut yaml_scroll_offset,
                 &mut TextSearchState::default(),
                 &theme,
@@ -691,8 +727,8 @@ fn test_render_resource_yaml_with_data() {
                 &Some("Kustomization:flux-system:my-kustomization".to_string()),
                 &state,
                 &resource_objects,
-                &Some(resource_json),
-                &None,
+                Some(&resource_json),
+                false,
                 &mut yaml_scroll_offset,
                 &mut TextSearchState::default(),
                 &theme,


### PR DESCRIPTION
Signed-off-by: Daniel Guns <danbguns@gmail.com>

Closes #191

  ### What

  **Events in describe (`d`)** — every resource's describe view now ends with a
  kubectl-style Events section (TYPE / REASON / AGE / COUNT / FROM / MESSAGE),
  Warnings highlighted, multi-line messages preserved. Fetched alongside the
  object in one pass; degrades to an "Events unavailable" notice (e.g. RBAC)
  instead of failing the describe.

  **Live events feed (`:events`, alias `:ev`)** — a real-time feed of core/v1
  Events for the current namespace scope, cluster-wide with `:ns all` (a
  NAMESPACE column appears). Newest first, deduplicated by UID, bounded at 1000
  entries, filterable with `/`. The events watcher starts lazily when the view
  opens and stops when it's left — zero overhead otherwise — and survives
  namespace and context switches.

  **Act on resources from anywhere** — a new `view_target()` resolver makes the
  resource-action keys work in every view: `y`/`d` on an event's involved object
  (including non-Flux kinds like Pods, via live API fetch) or on a focused graph
  node, `Enter`/`t`/`g`/`h` and operations for watched Flux resources. Back
  always returns to the view you came from.

  ### Refactors (landed first, no behavior change)

  - Generic `AsyncTask<K, T>` replaces the five copy-pasted
    `*_pending`/`*_fetched`/`*_rx` triplets and their trigger/poll methods
  - Fetch requests are typed `ResourceKey`s — no more string key re-parsing in
    the main loop
  - The events watcher gets an independent lifecycle from the resource watchers
    (groundwork for the log viewer and workload drill-down)

  ### Fixes

  - `:all` now returns to the resource list from the events/favorites views
    instead of leaving you stranded with cleared filters
  - Unwatched-object messages name the namespace and point at `y`/`d`
  - `anyhow` 1.0.102 → 1.0.103 (RUSTSEC-2026-0190) and dead-code warnings

  ### Testing

  571 tests passing (`just ci` green, zero warnings): AsyncTask lifecycle, event
  JSON parsing (core/v1 + events.k8s.io field styles), store dedup/eviction,
  describe section rendering, feed rendering via TestBackend, and handler flows
  (open/close, Enter-jump, filters, `:all`). Verified manually against a live
  cluster.
