### PR TITLE
add back sock5 proxy with regression test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Restored SOCKS5 proxy support (#202): the `kube/socks5` cargo feature was
+  accidentally dropped in a dependency cleanup (#182), so kubeconfigs with
+  `proxy-url: socks5://…` failed at startup with `requires the disabled
+  feature "kube/socks5"`. Regression tests now build a client through both
+  socks5 and http proxy configs so a missing proxy feature fails CI.
+
 ## [0.11.0] - 2026-07-06
 
 ### Changes\n- Version bump to 0.11.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,11 +70,16 @@ vendored-openssl = ["openssl/vendored"]
 
 [dependencies]
 # Kubernetes client with HTTP proxy support - use openssl-tls for better cert support
+# NOTE: "http-proxy" and "socks5" look unused to dependency-pruning tools (no
+# code references them) but they gate kubeconfig `proxy-url:` support inside
+# kube itself — removing them breaks proxied clusters at runtime (#202).
+# Guarded by proxy tests in src/kube/mod.rs.
 kube = { version = "4.0.0", default-features = false, features = [
     "client",
     "runtime",
     "derive",
     "http-proxy",
+    "socks5",
     "openssl-tls",
 ] }
 # k8s-openapi version feature - must match kube-rs version

--- a/src/kube/mod.rs
+++ b/src/kube/mod.rs
@@ -542,6 +542,44 @@ pub async fn discover_namespaces_with_flux_resources(client: &Client) -> Result<
 mod tests {
     use super::*;
 
+    /// Build a client from a config that routes through the given proxy URL.
+    /// `Client::try_from` is where kube rejects proxy schemes whose cargo
+    /// feature is not compiled in — no network I/O happens here (a runtime is
+    /// still required because the client spawns its buffer task).
+    fn client_with_proxy(proxy_url: &str) -> kube::Result<Client> {
+        let mut config = kube::Config::new("https://kubernetes.example.com".parse().unwrap());
+        config.proxy_url = Some(proxy_url.parse().unwrap());
+        Client::try_from(config)
+    }
+
+    /// Regression test for #202: the `kube/socks5` cargo feature was dropped
+    /// in a dependency cleanup (it looks unused — no code references it), and
+    /// every cluster with `proxy-url: socks5://…` in its kubeconfig failed at
+    /// startup with: configured proxy … requires the disabled feature
+    /// "kube/socks5". This fails at compile-config time if the feature is
+    /// ever removed again.
+    #[tokio::test]
+    async fn test_client_supports_socks5_proxy() {
+        let result = client_with_proxy("socks5://127.0.0.1:3129");
+        assert!(
+            result.is_ok(),
+            "socks5 proxy-url must be supported (kube/socks5 feature): {:?}",
+            result.err()
+        );
+    }
+
+    /// Companion guard for the `kube/http-proxy` feature (same failure mode
+    /// as #202 for `proxy-url: http://…` kubeconfigs).
+    #[tokio::test]
+    async fn test_client_supports_http_proxy() {
+        let result = client_with_proxy("http://127.0.0.1:3128");
+        assert!(
+            result.is_ok(),
+            "http proxy-url must be supported (kube/http-proxy feature): {:?}",
+            result.err()
+        );
+    }
+
     #[test]
     fn test_is_internal_host_private_ips() {
         assert!(is_internal_host("10.0.0.1"));

--- a/src/tui/views/detail.rs
+++ b/src/tui/views/detail.rs
@@ -22,7 +22,7 @@ fn capitalize_first(key: &str) -> String {
         format!(
             "{}{}",
             first.to_uppercase(),
-            &key[first.len_utf8()..].to_lowercase()
+            key[first.len_utf8()..].to_lowercase()
         )
     } else {
         key.to_string()


### PR DESCRIPTION
Signed-off-by: Daniel Guns <danbguns@gmail.com>

Closes #202

  The `kube/socks5` cargo feature was accidentally dropped in the #182 dependency
  cleanup — proxy features gate `proxy-url:` support inside kube itself and are
  referenced by no flux9s code, so they look "unused" to pruning tools. Any
  kubeconfig with `proxy-url: socks5://…` failed at startup since 0.11.0.

  - Restore `socks5` to the kube features, with a comment warning against
    re-pruning it (or `http-proxy`)
  - Add regression tests that build a client through socks5 and http proxied
    configs — no network needed, so a missing proxy feature now fails CI