### PR TITLE
kind testing, rset graph

### DIFF
--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -1,0 +1,99 @@
+name: Live Cluster Tests
+
+# Runs the #[ignore]d live regression suite (tests/live_tests.rs) against
+# real kind clusters built by scripts/dev-clusters.sh. Catches what unit CI
+# can't: API discovery, watch/list/log wire behavior, and upstream
+# flux-operator condition-message formats drifting under flux9s.
+#
+# Weekly rather than per-PR: the failure mode being guarded is upstream
+# drift (new Flux/flux-operator releases), not PR regressions.
+
+on:
+  schedule:
+    # Mondays 06:00 UTC
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+    inputs:
+      clusters:
+        description: "Dev clusters to build (dev-clusters.sh mode)"
+        type: choice
+        options:
+          - ci # simple + legacy — everything the live suite asserts against
+          - simple
+          - legacy
+          - all
+        default: ci
+
+permissions:
+  contents: read
+
+concurrency:
+  group: live-tests
+  cancel-in-progress: false
+
+env:
+  KIND_VERSION: v0.30.0
+  # kind pulls images and starts controllers from cold — give the script's
+  # readiness waits CI-appropriate headroom (defaults are tuned for warm
+  # local Docker).
+  FLUX9S_DEV_DEPLOY_WAIT_TIMEOUT: 180s
+  FLUX9S_DEV_CRD_WAIT_RETRIES: "30"
+  FLUX9S_DEV_CRD_WAIT_SLEEP_SECONDS: "5"
+
+jobs:
+  live-tests:
+    name: Live regression suite (kind)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-live-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-live-
+            ${{ runner.os }}-cargo-
+
+      - name: Install kind
+        run: |
+          # ubuntu-latest ships a root-owned kind at /usr/local/bin — sudo so
+          # our pinned version deterministically replaces it.
+          sudo curl -fsSLo /usr/local/bin/kind \
+            "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
+          sudo chmod +x /usr/local/bin/kind
+          kind version
+          # kubectl, helm, and envsubst ship on ubuntu-latest runners
+          kubectl version --client
+          helm version --short
+
+      - name: Compile live tests (before spending cluster time)
+        run: cargo test --test live_tests --no-run
+
+      - name: Build dev clusters
+        run: ./scripts/dev-clusters.sh "${{ inputs.clusters || 'ci' }}"
+
+      - name: Run live regression suite
+        run: cargo test --test live_tests -- --ignored --test-threads=1 --nocapture
+
+      - name: Dump cluster diagnostics on failure
+        if: failure()
+        run: |
+          for ctx in kind-flux9s-simple kind-flux9s-legacy; do
+            kubectl config get-contexts -o name | grep -qx "$ctx" || continue
+            echo "════ $ctx ════"
+            kubectl --context "$ctx" get fluxinstance,resourcesets,resourcesetinputproviders,kustomizations,gitrepositories,ocirepositories -A 2>/dev/null || true
+            kubectl --context "$ctx" get events -n flux-resources --sort-by=.lastTimestamp 2>/dev/null | tail -30 || true
+            echo "──── flux-operator logs ────"
+            kubectl --context "$ctx" logs -n flux-system deploy/flux-operator --tail=50 2>/dev/null || true
+          done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Graph view no longer flashes when the focused node is taller than the
+  viewport (e.g. a FluxInstance's workload group): the focus auto-scroll now
+  pins oversized nodes to their top edge instead of oscillating between
+  showing their top and bottom on alternating frames.
+
 ### Added
+- Graph view downstream discovery for ResourceSet and FluxInstance (#204):
+  their `status.inventory` now renders like a Kustomization's — Flux resources
+  produced by a ResourceSet become individual navigable nodes, Deployments and
+  other workloads get the workload group with live status, and arbitrary kinds
+  (Namespaces, CRDs, custom resources) aggregate into the resource group.
 - Controller pod log viewer (#192): `:logs` opens a submenu of the discovered
   Flux controller pods (`:logs <pod|prefix>` streams one directly). Logs are
   tailed and followed live in a bounded buffer; scrolling up pauses following
@@ -66,6 +77,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mismatches are visible instead of just confusing.
 
 ### Internal
+- New live-cluster regression suite (`tests/live_tests.rs`, all `#[ignore]`d):
+  exact assertions against the dev kind clusters' planted fixtures — graph
+  inventory, describe events, the operator's step-failure message format, pod
+  log streaming, and legacy v1beta2 version-fallback discovery. Run locally
+  with `just test-live` after `./scripts/dev-clusters.sh ci`, or via the new
+  weekly/dispatch `live-tests.yml` workflow.
 - New generic `AsyncTask<K, T>` owns the request/dispatch/poll lifecycle for
   view fetches, replacing the five copy-pasted `*_pending`/`*_fetched`/`*_rx`
   field triplets and their hand-rolled trigger/poll methods.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,6 +180,13 @@ path = "tests/field_extraction.rs"
 name = "trace_tests"
 path = "tests/trace_tests.rs"
 
+# Live-cluster regression tests — every test is #[ignore]d; run via
+# `just test-live` after `./scripts/dev-clusters.sh ci`, or by the
+# live-tests.yml workflow (weekly / manual dispatch).
+[[test]]
+name = "live_tests"
+path = "tests/live_tests.rs"
+
 [[test]]
 name = "snapshot_tests"
 path = "tests/snapshot_tests.rs"

--- a/docs/content/user-guide/_index.md
+++ b/docs/content/user-guide/_index.md
@@ -215,7 +215,11 @@ Visualize resource relationships and dependencies. Shows upstream sources and do
 The graph view displays:
 
 - **Upstream sources** (GitRepository, HelmRepository, etc.)
-- **Managed resources** (workloads, ConfigMaps, Services, etc.)
+- **Managed resources** (workloads, ConfigMaps, Services, etc.) — for
+  Kustomizations, HelmReleases, ResourceSets, and FluxInstances alike; a
+  ResourceSet's produced Flux resources appear as individual navigable nodes,
+  and arbitrary kinds (Namespaces, CRDs, custom resources) aggregate into
+  the resource group
 - **Resource groups** (aggregated by type)
 - **Workload groups** (aggregated workloads with status)
 

--- a/justfile
+++ b/justfile
@@ -20,6 +20,11 @@ test:
 test-integration:
     cargo test --test crd_compatibility --test resource_registry --test model_compatibility --test field_extraction --test trace_tests --test graph_tests
 
+# Run live-cluster regression tests against the dev kind clusters
+# (build them first: ./scripts/dev-clusters.sh ci)
+test-live:
+    cargo test --test live_tests -- --ignored --test-threads=1
+
 # Run cargo-audit to check for CVEs (ignores unmaintained warnings)
 audit:
     # RUSTSEC-2026-0002 is currently pulled in transitively via ratatui 0.29's lru dependency.

--- a/scripts/dev-clusters.sh
+++ b/scripts/dev-clusters.sh
@@ -3,8 +3,8 @@
 #
 # Creates three clearly-named clusters:
 #
-#   flux9s-simple   — Flux 2.8.x (current repo CRD baseline); day-to-day dev testing
-#   flux9s-stress   — Flux 2.5.x; 40+ resources of every kind for page-scroll / large lists
+#   flux9s-simple   — Flux 2.9.x + source-watcher; day-to-day dev testing (steps, AG, events)
+#   flux9s-stress   — Flux 2.7.x; 40+ resources of every kind for page-scroll / large lists
 #   flux9s-legacy   — Flux 2.2.x with OCIRepository/Bucket at v1beta2; tests the
 #                     version-fallback logic (flux9s tries v1 first, then v1beta2)
 #
@@ -16,6 +16,7 @@
 #   ./scripts/dev-clusters.sh simple       # build flux9s-simple only
 #   ./scripts/dev-clusters.sh stress       # build flux9s-stress only
 #   ./scripts/dev-clusters.sh legacy       # build flux9s-legacy only
+#   ./scripts/dev-clusters.sh ci           # build simple + legacy (live-test set)
 #   ./scripts/dev-clusters.sh all          # build all three clusters
 #   ./scripts/dev-clusters.sh delete       # delete all kind clusters and exit
 
@@ -37,7 +38,7 @@ STRESS_CLUSTER="flux9s-stress"
 LEGACY_CLUSTER="flux9s-legacy"
 
 FLUX_OPERATOR_CHART="oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator"
-FLUX_OPERATOR_VERSION="0.48.0"
+FLUX_OPERATOR_VERSION="0.55.0"
 DEPLOY_WAIT_TIMEOUT="${FLUX9S_DEV_DEPLOY_WAIT_TIMEOUT:-5s}"
 CRD_WAIT_RETRIES="${FLUX9S_DEV_CRD_WAIT_RETRIES:-5}"
 CRD_WAIT_SLEEP_SECONDS="${FLUX9S_DEV_CRD_WAIT_SLEEP_SECONDS:-3}"
@@ -302,7 +303,7 @@ run_build() {
 # ── cluster builders ───────────────────────────────────────────────────────────
 
 build_simple_cluster() {
-    header "Building  $SIMPLE_CLUSTER  (Flux 2.8.x — current repo CRD baseline)"
+    header "Building  $SIMPLE_CLUSTER  (Flux 2.9.x + source-watcher — current repo CRD baseline)"
 
     kind create cluster --name "$SIMPLE_CLUSTER" --wait 60s
     local ctx="kind-${SIMPLE_CLUSTER}"
@@ -310,6 +311,21 @@ build_simple_cluster() {
     install_flux_operator "$ctx"
     apply_fluxinstance "$ctx" "${MANIFEST_DIR}/fluxinstance.yaml"
     wait_for_flux_crds "$ctx"
+
+    # source-watcher CRDs (simple cluster only — the medium/legacy instances
+    # don't run the source-watcher component)
+    info "Waiting for source-watcher CRDs …"
+    for crd in \
+        artifactgenerators.source.extensions.fluxcd.io \
+        externalartifacts.source.toolkit.fluxcd.io; do
+        local retries="$CRD_WAIT_RETRIES"
+        while ! kubectl --context "$ctx" get crd "$crd" &>/dev/null; do
+            retries=$((retries - 1))
+            [ $retries -le 0 ] && { warn "Timed out waiting for $crd – skipping"; break; }
+            sleep "$CRD_WAIT_SLEEP_SECONDS"
+        done
+        success "  $crd"
+    done
 
     apply_simple_manifests "$ctx" "flux-resources"
 
@@ -320,7 +336,7 @@ build_simple_cluster() {
 }
 
 build_stress_cluster() {
-    header "Building  $STRESS_CLUSTER  (Flux 2.5.x — stress/page-scroll testing)"
+    header "Building  $STRESS_CLUSTER  (Flux 2.7.x — stress/page-scroll testing)"
 
     kind create cluster --name "$STRESS_CLUSTER" --wait 60s
     local ctx="kind-${STRESS_CLUSTER}"
@@ -407,13 +423,19 @@ main() {
             run_build "$SIMPLE_CLUSTER" build_simple_cluster
             run_build "$STRESS_CLUSTER" build_stress_cluster
             ;;
+        # The live-test set (.github/workflows/live-tests.yml): the clusters
+        # tests/live_tests.rs asserts against, skipping the heavy stress cluster.
+        ci)
+            run_build "$SIMPLE_CLUSTER" build_simple_cluster
+            run_build "$LEGACY_CLUSTER" build_legacy_cluster
+            ;;
         all)
             run_build "$SIMPLE_CLUSTER" build_simple_cluster
             run_build "$STRESS_CLUSTER" build_stress_cluster
             run_build "$LEGACY_CLUSTER" build_legacy_cluster
             ;;
         *)
-            die "Unknown mode '$mode'. Use: both | simple | stress | legacy | all | delete"
+            die "Unknown mode '$mode'. Use: both | simple | stress | legacy | ci | all | delete"
             ;;
     esac
 
@@ -422,10 +444,10 @@ main() {
     echo "  Available clusters:"
     kind get clusters 2>/dev/null | sed 's/^/    • kind-/'
     echo
-    echo "  Day-to-day dev (Flux 2.8.x, current repo CRDs):"
+    echo "  Day-to-day dev (Flux 2.9.x, current repo CRDs):"
     echo "    kubectl config use-context kind-${SIMPLE_CLUSTER} && cargo run"
     echo
-    echo "  Page-scroll stress testing (Flux 2.5.x):"
+    echo "  Page-scroll stress testing (Flux 2.7.x):"
     echo "    kubectl config use-context kind-${STRESS_CLUSTER} && cargo run"
     echo "    → Press Ctrl+f / Ctrl+b to page through the list"
     echo

--- a/scripts/dev-manifests/fluxinstance-medium.yaml
+++ b/scripts/dev-manifests/fluxinstance-medium.yaml
@@ -8,8 +8,8 @@ metadata:
 spec:
   distribution:
     # Pin to a mid-series release band where OCIRepository/Bucket/Helm* are stable,
-    # but the cluster still represents an older CRD surface than the repo baseline.
-    version: "2.5.x"
+    # but the cluster still represents an older (yet supported) CRD surface than the repo baseline.
+    version: "2.7.x"
     registry: "ghcr.io/fluxcd"
   components:
     - source-controller

--- a/scripts/dev-manifests/fluxinstance.yaml
+++ b/scripts/dev-manifests/fluxinstance.yaml
@@ -9,7 +9,7 @@ spec:
   distribution:
     # Pin to the current Flux release line represented by this repo's generated CRDs.
     # This keeps the "simple" dev cluster aligned with the latest API surface flux9s targets.
-    version: "2.8.x"
+    version: "2.9.x"
     registry: "ghcr.io/fluxcd"
   components:
     - source-controller
@@ -18,6 +18,8 @@ spec:
     - notification-controller
     - image-reflector-controller
     - image-automation-controller
+    # source-watcher provides ArtifactGenerator + ExternalArtifact (both watched by flux9s)
+    - source-watcher
   cluster:
     type: kubernetes
     multitenant: false

--- a/scripts/dev-manifests/simple/kustomize.yaml
+++ b/scripts/dev-manifests/simple/kustomize.yaml
@@ -62,3 +62,21 @@ spec:
   sourceRef:
     kind: Bucket
     name: terraform-state
+---
+# Deliberate failure case: the path doesn't exist in the repo, so this
+# Kustomization emits ReconciliationFailed Warning events on every retry —
+# feed for the :events view, describe Events section, and unhealthy filter.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: broken-path-demo
+  namespace: flux-resources
+  labels: {app.kubernetes.io/managed-by: flux9s-dev}
+spec:
+  interval: 5m
+  retryInterval: 2m
+  path: ./does-not-exist
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system

--- a/scripts/dev-manifests/simple/operator.yaml
+++ b/scripts/dev-manifests/simple/operator.yaml
@@ -1,33 +1,44 @@
-# Flux Operator resources — ResourceSetInputProviders feed into ResourceSets
-# ResourceSetInputProvider/github-branches ─┬─► ResourceSet/per-branch-envs
-# ResourceSetInputProvider/cluster-inventory ┴─► ResourceSet/cluster-configs (multi-input)
+# Flux Operator resources — ResourceSetInputProviders feed into ResourceSets,
+# plus step-based ResourceSets (flux-operator v0.53+) for testing the Steps
+# section in the detail view.
+#
+#   RSIP/flux2-branches (public GitHub, works) ──► ResourceSet/per-branch-envs
+#   RSIP/gitlab-broken  (missing secret, FAILS) ─► deliberate error state
+#   ResourceSet/staged-rollout        — 3 steps, all succeed (done/done/done)
+#   ResourceSet/staged-rollout-broken — fails at step 2 (done/failed/pending)
 apiVersion: fluxcd.controlplane.io/v1
 kind: ResourceSetInputProvider
 metadata:
-  name: github-branches
+  name: flux2-branches
   namespace: flux-resources
   annotations:
-    fluxcd.controlplane.io/reconcileEvery: "30s"
+    fluxcd.controlplane.io/reconcileEvery: "10m"
   labels: {app.kubernetes.io/managed-by: flux9s-dev}
 spec:
   type: GitHubBranch
+  # Public repo — no token needed (subject to anonymous API rate limits,
+  # hence the long reconcile interval)
   url: https://github.com/fluxcd/flux2
-  secretRef:
-    name: github-token
+  filter:
+    limit: 3
+    includeBranch: "^(main|release-.*)$"
 ---
+# Deliberate failure case: references a Secret that doesn't exist, so this
+# provider stays not-ready and emits Warning events — feed for the :events
+# view and describe Events section.
 apiVersion: fluxcd.controlplane.io/v1
 kind: ResourceSetInputProvider
 metadata:
-  name: cluster-inventory
+  name: gitlab-broken
   namespace: flux-resources
   annotations:
-    fluxcd.controlplane.io/reconcileEvery: "1m"
+    fluxcd.controlplane.io/reconcileEvery: "5m"
   labels: {app.kubernetes.io/managed-by: flux9s-dev}
 spec:
   type: GitLabBranch
   url: https://gitlab.com/fluxcd/flux2
   secretRef:
-    name: gitlab-token
+    name: gitlab-token-does-not-exist
 ---
 apiVersion: fluxcd.controlplane.io/v1
 kind: ResourceSet
@@ -38,33 +49,137 @@ metadata:
 spec:
   inputsFrom:
     - kind: ResourceSetInputProvider
-      name: github-branches
+      name: flux2-branches
   resources:
     - apiVersion: v1
       kind: ConfigMap
       metadata:
-        name: branch-${{ inputs.branch }}
+        name: branch-<< inputs.id >>
         namespace: flux-resources
       data:
-        branch: ${{ inputs.branch }}
+        branch: << inputs.branch | quote >>
+        sha: << inputs.sha | quote >>
 ---
+# Step-based ResourceSet (green path): pre-deploy Job → deploy ConfigMaps →
+# post-deploy Job, all self-contained so every step reaches "done".
 apiVersion: fluxcd.controlplane.io/v1
 kind: ResourceSet
 metadata:
-  name: cluster-configs
+  name: staged-rollout
   namespace: flux-resources
+  annotations:
+    fluxcd.controlplane.io/reconcileEvery: "30m"
   labels: {app.kubernetes.io/managed-by: flux9s-dev}
 spec:
-  inputsFrom:
-    - kind: ResourceSetInputProvider
-      name: github-branches
-    - kind: ResourceSetInputProvider
-      name: cluster-inventory
-  resources:
-    - apiVersion: v1
-      kind: ConfigMap
-      metadata:
-        name: cluster-${{ inputs.region }}
-        namespace: flux-resources
-      data:
-        region: ${{ inputs.region }}
+  wait: true
+  steps:
+    - name: pre-deploy
+      timeout: 2m
+      resources:
+        - apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: staged-db-migration
+            namespace: flux-resources
+            annotations:
+              fluxcd.controlplane.io/force: enabled
+          spec:
+            backoffLimit: 0
+            template:
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: migration
+                    image: busybox:1.36
+                    command: ["sh", "-c", "echo running db migration && sleep 2"]
+    - name: deploy
+      timeout: 2m
+      resources:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: staged-app-config
+            namespace: flux-resources
+          data:
+            feature: "enabled"
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: staged-app-routes
+            namespace: flux-resources
+          data:
+            route: "/api/v2"
+    - name: post-deploy
+      timeout: 2m
+      resources:
+        - apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: staged-cache-warmup
+            namespace: flux-resources
+            annotations:
+              fluxcd.controlplane.io/force: enabled
+          spec:
+            backoffLimit: 0
+            template:
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: cache
+                    image: busybox:1.36
+                    command: ["sh", "-c", "echo refreshing cache && sleep 2"]
+---
+# Step-based ResourceSet (failure path): step 2's Job always exits 1, so the
+# ResourceSet sticks at "verify" failed — detail view shows
+# done / failed / pending, and each retry emits Warning events.
+apiVersion: fluxcd.controlplane.io/v1
+kind: ResourceSet
+metadata:
+  name: staged-rollout-broken
+  namespace: flux-resources
+  annotations:
+    fluxcd.controlplane.io/reconcileEvery: "15m"
+  labels: {app.kubernetes.io/managed-by: flux9s-dev}
+spec:
+  wait: true
+  steps:
+    - name: prepare
+      timeout: 2m
+      resources:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: broken-rollout-config
+            namespace: flux-resources
+          data:
+            stage: "prepare"
+    - name: verify
+      timeout: 1m
+      resources:
+        - apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: broken-verify
+            namespace: flux-resources
+            annotations:
+              fluxcd.controlplane.io/force: enabled
+              fluxcd.controlplane.io/recreateOnFailure: enabled
+          spec:
+            backoffLimit: 0
+            template:
+              spec:
+                restartPolicy: Never
+                containers:
+                  - name: verify
+                    image: busybox:1.36
+                    command: ["sh", "-c", "echo verification failed && exit 1"]
+    - name: finalize
+      timeout: 1m
+      resources:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: broken-rollout-done
+            namespace: flux-resources
+          data:
+            stage: "finalize"

--- a/scripts/dev-manifests/simple/source-watcher.yaml
+++ b/scripts/dev-manifests/simple/source-watcher.yaml
@@ -1,0 +1,25 @@
+# source-watcher resources — ArtifactGenerator produces ExternalArtifacts
+# from the flux-system GitRepository (both kinds are watched by flux9s; the
+# graph view supports ArtifactGenerator fan-out).
+#
+#   GitRepository/flux-system ─► ArtifactGenerator/example-apps ─► ExternalArtifact(s)
+apiVersion: source.extensions.fluxcd.io/v1beta1
+kind: ArtifactGenerator
+metadata:
+  name: example-apps
+  namespace: flux-resources
+  labels: {app.kubernetes.io/managed-by: flux9s-dev}
+spec:
+  sources:
+    - alias: repo
+      kind: GitRepository
+      name: flux-system
+  artifacts:
+    - name: apps-base
+      copy:
+        - from: "@repo/apps/base/**"
+          to: "@artifact/"
+    - name: apps-staging
+      copy:
+        - from: "@repo/apps/staging/**"
+          to: "@artifact/"

--- a/scripts/dev-manifests/stress/operator.yaml.tpl
+++ b/scripts/dev-manifests/stress/operator.yaml.tpl
@@ -40,10 +40,10 @@ spec:
     - apiVersion: v1
       kind: ConfigMap
       metadata:
-        name: branch-${{ inputs.branch }}${SUFFIX}
+        name: branch-<< inputs.branch >>${SUFFIX}
         namespace: ${NS}
       data:
-        branch: ${{ inputs.branch }}
+        branch: << inputs.branch >>
 ---
 apiVersion: fluxcd.controlplane.io/v1
 kind: ResourceSet
@@ -61,7 +61,7 @@ spec:
     - apiVersion: v1
       kind: ConfigMap
       metadata:
-        name: cluster-${{ inputs.region }}${SUFFIX}
+        name: cluster-<< inputs.region >>${SUFFIX}
         namespace: ${NS}
       data:
-        region: ${{ inputs.region }}
+        region: << inputs.region >>

--- a/src/kube/inventory.rs
+++ b/src/kube/inventory.rs
@@ -358,4 +358,58 @@ mod tests {
         assert_eq!(name, "repo");
         assert_eq!(url, "https://github.com/user/repo.git");
     }
+
+    /// A step-based ResourceSet's inventory (same `status.inventory.entries`
+    /// format as Kustomization) covering the #204 cases: cluster-scoped
+    /// resources (Namespace, CRD), a workload, plain resources, and a
+    /// produced Flux resource that must become an individual graph node.
+    #[test]
+    fn test_resource_set_inventory_extraction_and_grouping() {
+        let obj = json!({
+            "apiVersion": "fluxcd.controlplane.io/v1",
+            "kind": "ResourceSet",
+            "metadata": {"name": "staged-rollout", "namespace": "flux-resources"},
+            "status": {
+                "inventory": {
+                    "entries": [
+                        // Cluster-scoped, no group
+                        {"id": "_demo__Namespace", "v": "v1"},
+                        // Cluster-scoped CRD (has an API group)
+                        {"id": "_widgets.example.com_apiextensions.k8s.io_CustomResourceDefinition", "v": "v1"},
+                        // Workload
+                        {"id": "flux-resources_staged-app_apps_Deployment", "v": "v1"},
+                        // Plain namespaced resources (real ids from the dev cluster)
+                        {"id": "flux-resources_staged-app-config__ConfigMap", "v": "v1"},
+                        {"id": "flux-resources_staged-db-migration_batch_Job", "v": "v1"},
+                        // A Flux resource produced by the ResourceSet
+                        {"id": "flux-resources_podinfo_kustomize.toolkit.fluxcd.io_Kustomization", "v": "v1"}
+                    ]
+                }
+            }
+        });
+
+        let entries = extract_inventory(&obj).unwrap();
+        assert_eq!(entries.len(), 6);
+
+        let crd = entries
+            .iter()
+            .find(|e| e.kind == "CustomResourceDefinition")
+            .expect("CRD entry parses");
+        assert_eq!(crd.name, "widgets.example.com");
+        assert_eq!(crd.namespace, "", "cluster-scoped CRD has no namespace");
+
+        let groups = group_inventory(entries);
+        // The produced Kustomization is an individual, navigable node
+        assert_eq!(groups.flux.len(), 1);
+        assert_eq!(groups.flux[0].kind, "Kustomization");
+        assert_eq!(groups.flux[0].name, "podinfo");
+        // The Deployment gets workload treatment (status fetch + group node)
+        assert_eq!(groups.workloads.len(), 1);
+        assert_eq!(groups.workloads[0].name, "staged-app");
+        // Everything else aggregates by kind — including arbitrary/CRD kinds
+        assert_eq!(groups.resources.get("Namespace"), Some(&1));
+        assert_eq!(groups.resources.get("CustomResourceDefinition"), Some(&1));
+        assert_eq!(groups.resources.get("ConfigMap"), Some(&1));
+        assert_eq!(groups.resources.get("Job"), Some(&1));
+    }
 }

--- a/src/models/flux_resource_kind.rs
+++ b/src/models/flux_resource_kind.rs
@@ -195,6 +195,24 @@ impl FluxResourceKind {
         )
     }
 
+    /// Whether this kind records the objects it applies in
+    /// `status.inventory.entries`, so the graph can discover its downstream
+    /// resources from the inventory:
+    /// - Kustomization
+    /// - ResourceSet
+    /// - FluxInstance
+    ///
+    /// HelmRelease is deliberately excluded — its inventory lives in Helm
+    /// storage Secrets and has a dedicated discovery path.
+    pub fn has_inventory_downstream(&self) -> bool {
+        matches!(
+            self,
+            FluxResourceKind::Kustomization
+                | FluxResourceKind::ResourceSet
+                | FluxResourceKind::FluxInstance
+        )
+    }
+
     /// Check if this resource type supports reconciliation history
     ///
     /// Only resources with status.history field support history:
@@ -1136,5 +1154,25 @@ mod tests {
 
         let fields = FluxResourceKind::ResourceSet.extract_fields(&obj);
         assert!(!fields.contains_key("INPUTS"));
+    }
+
+    #[test]
+    fn test_has_inventory_downstream() {
+        // The status.inventory.entries kinds share the graph discovery path
+        assert!(FluxResourceKind::Kustomization.has_inventory_downstream());
+        assert!(FluxResourceKind::ResourceSet.has_inventory_downstream());
+        assert!(FluxResourceKind::FluxInstance.has_inventory_downstream());
+        // HelmRelease has its own path (Helm storage Secrets)
+        assert!(!FluxResourceKind::HelmRelease.has_inventory_downstream());
+        assert!(!FluxResourceKind::GitRepository.has_inventory_downstream());
+        // Every inventory-downstream kind must also support the graph view
+        for kind in FluxResourceKind::all() {
+            if kind.has_inventory_downstream() {
+                assert!(
+                    kind.supports_graph(),
+                    "{kind:?} has inventory but no graph support"
+                );
+            }
+        }
     }
 }

--- a/src/trace/graph_builder.rs
+++ b/src/trace/graph_builder.rs
@@ -255,12 +255,22 @@ async fn discover_downstream_resources(
     name: &str,
     from_node_id: &str,
 ) -> Result<()> {
-    // For Kustomization and HelmRelease, discover managed resources
+    // Inventory-carrying kinds (Kustomization, ResourceSet, FluxInstance)
+    // share the status.inventory discovery path; HelmRelease has its own
+    // (inventory lives in Helm storage Secrets).
     let flux_kind = FluxResourceKind::parse_optional(resource_type);
 
     match flux_kind {
-        Some(FluxResourceKind::Kustomization) => {
-            discover_kustomization_resources(client, graph, namespace, name, from_node_id).await?;
+        Some(kind) if kind.has_inventory_downstream() => {
+            discover_inventory_resources(
+                client,
+                graph,
+                resource_type,
+                namespace,
+                name,
+                from_node_id,
+            )
+            .await?;
         }
         Some(FluxResourceKind::HelmRelease) => {
             discover_helmrelease_resources(client, graph, namespace, name, from_node_id).await?;
@@ -274,31 +284,36 @@ async fn discover_downstream_resources(
     Ok(())
 }
 
-/// Discover resources managed by a Kustomization using inventory extraction
-async fn discover_kustomization_resources(
+/// Discover managed resources from `status.inventory.entries` — the shared
+/// downstream path for Kustomization, ResourceSet, and FluxInstance (see
+/// [`FluxResourceKind::has_inventory_downstream`]). Arbitrary inventory kinds
+/// (Namespaces, CRDs, custom resources) land in the aggregated resource
+/// group; Flux resources become individual navigable nodes.
+async fn discover_inventory_resources(
     client: &kube::Client,
     graph: &mut ResourceGraph,
+    resource_type: &str,
     namespace: &str,
-    kustomization_name: &str,
+    name: &str,
     from_node_id: &str,
 ) -> Result<()> {
-    // Fetch the Kustomization resource to extract inventory
+    // Fetch the resource to extract its inventory
     let api_resource =
-        get_api_resource_with_fallback(client, "Kustomization", namespace, kustomization_name)
-            .await?;
+        get_api_resource_with_fallback(client, resource_type, namespace, name).await?;
     let api: Api<DynamicObject> = Api::namespaced_with(client.clone(), namespace, &api_resource);
     let obj = api
-        .get(kustomization_name)
+        .get(name)
         .await
-        .context("Failed to fetch Kustomization")?;
+        .with_context(|| format!("Failed to fetch {}", resource_type))?;
     let obj_value = serde_json::to_value(&obj).context("Failed to serialize resource")?;
 
     // Extract and group inventory
     if let Ok(entries) = extract_inventory(&obj_value) {
         tracing::debug!(
-            "Extracted {} inventory entries from Kustomization {}",
+            "Extracted {} inventory entries from {} {}",
             entries.len(),
-            kustomization_name
+            resource_type,
+            name
         );
         let groups = group_inventory(entries);
         tracing::debug!(
@@ -450,8 +465,9 @@ async fn discover_kustomization_resources(
         }
     } else {
         tracing::debug!(
-            "No inventory found for Kustomization {} in namespace {}",
-            kustomization_name,
+            "No inventory found for {} {} in namespace {}",
+            resource_type,
+            name,
             namespace
         );
     }

--- a/src/tui/views/graph.rs
+++ b/src/tui/views/graph.rs
@@ -82,7 +82,7 @@ pub fn render_resource_graph(
         0
     };
 
-    // Auto-scroll so the focused node stays fully on screen. Positions are only
+    // Auto-scroll so the focused node stays on screen. Positions are only
     // known after layout, so this runs here rather than in the event handler.
     if let Some((node_y, node_height)) = focus_index.and_then(|idx| {
         graph.nodes.get(idx).and_then(|node| {
@@ -94,17 +94,36 @@ pub fn render_resource_graph(
             })
         })
     }) {
-        if node_y < *scroll_offset {
-            *scroll_offset = node_y;
-        } else if node_y + node_height > *scroll_offset + visible_height {
-            *scroll_offset = (node_y + node_height).saturating_sub(visible_height);
-        }
+        *scroll_offset = follow_focus_scroll(*scroll_offset, node_y, node_height, visible_height);
     }
 
     *scroll_offset = (*scroll_offset).min(max_scroll);
 
     // Render graph using improved layout with line-based scrolling
     render_graph_nodes_and_edges(f, inner_area, &graph, *scroll_offset, focus_index, theme);
+}
+
+/// Scroll offset that keeps the focused node visible: scrolls up to its top
+/// edge, or down until its bottom edge fits. For nodes **taller than the
+/// viewport** (e.g. a FluxInstance's workload group with many controllers),
+/// the result is pinned to the node's top — without the pin, the up- and
+/// down-branches ping-pong on alternating frames, flashing the whole graph.
+/// Pure so the fixed-point behaviour is unit testable.
+fn follow_focus_scroll(
+    scroll_offset: usize,
+    node_y: usize,
+    node_height: usize,
+    visible_height: usize,
+) -> usize {
+    if node_y < scroll_offset {
+        node_y
+    } else if node_y + node_height > scroll_offset + visible_height {
+        (node_y + node_height)
+            .saturating_sub(visible_height)
+            .min(node_y)
+    } else {
+        scroll_offset
+    }
 }
 
 /// Pure geometry for one parent→children connector, in scroll-adjusted,
@@ -833,7 +852,7 @@ fn render_node_text(
 
 #[cfg(test)]
 mod tests {
-    use super::{box_glyph, fanout_routes};
+    use super::{box_glyph, fanout_routes, follow_focus_scroll};
     use crate::trace::{GraphEdge, GraphNode, NodeType, RelationshipType, ResourceGraph};
 
     #[test]
@@ -911,5 +930,41 @@ mod tests {
         graph.add_node(node("solo", NodeType::Object, None));
         graph.calculate_layout(100, 50);
         assert!(fanout_routes(&graph, 100, 0).is_empty());
+    }
+
+    /// Regression: a focused node taller than the viewport (FluxInstance
+    /// workload group with many controllers) must not make the scroll
+    /// oscillate between frames — the graph flashed continuously.
+    #[test]
+    fn follow_focus_scroll_is_stable_for_oversized_nodes() {
+        // Node at y=10, 12 rows tall, viewport only 8 rows
+        let first = follow_focus_scroll(0, 10, 12, 8);
+        let second = follow_focus_scroll(first, 10, 12, 8);
+        assert_eq!(first, 10, "oversized node pins to its top edge");
+        assert_eq!(second, first, "scroll must reach a fixed point");
+
+        // General fixed-point property across sizes and starting offsets
+        for node_y in [0usize, 5, 20] {
+            for node_height in [1usize, 8, 30] {
+                for start in [0usize, 7, 25, 60] {
+                    let a = follow_focus_scroll(start, node_y, node_height, 8);
+                    let b = follow_focus_scroll(a, node_y, node_height, 8);
+                    assert_eq!(
+                        a, b,
+                        "oscillation at start={start} y={node_y} h={node_height}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn follow_focus_scroll_keeps_fitting_nodes_visible() {
+        // Node fits: scrolling up to reveal it
+        assert_eq!(follow_focus_scroll(20, 10, 4, 8), 10);
+        // Node fits: scrolling down until its bottom edge is visible
+        assert_eq!(follow_focus_scroll(0, 10, 4, 8), 6);
+        // Already fully visible: no movement
+        assert_eq!(follow_focus_scroll(8, 10, 4, 8), 8);
     }
 }

--- a/tests/live_tests.rs
+++ b/tests/live_tests.rs
@@ -1,0 +1,240 @@
+//! Live regression tests against the flux9s dev kind clusters.
+//!
+//! Every test here is `#[ignore]`d: `just ci` never runs them (no cluster in
+//! unit CI). They run:
+//!   - locally:  `./scripts/dev-clusters.sh ci` then `just test-live`
+//!   - in CI:    .github/workflows/live-tests.yml (weekly + manual dispatch)
+//!
+//! The dev-cluster script plants deterministic fixtures (the staged-rollout
+//! ResourceSets, broken-path-demo Kustomization, legacy v1beta2 sources), so
+//! these tests make exact assertions against a real API server — the layer
+//! unit tests can't reach: discovery, watch/list/log wire formats, and the
+//! operator's actual condition-message formats.
+//!
+//! Discipline: only assert on state `dev-clusters.sh` creates
+//! deterministically. Never assert on public-internet sources (e.g. the
+//! flux2-branches RSIP) or exact timing — eventual state with a bounded poll.
+
+use std::time::{Duration, Instant};
+
+/// Context of the primary dev cluster (Flux 2.9.x + source-watcher).
+fn simple_context() -> String {
+    std::env::var("FLUX9S_LIVE_SIMPLE_CONTEXT").unwrap_or_else(|_| "kind-flux9s-simple".to_string())
+}
+
+/// Context of the legacy dev cluster (Flux 2.2.x, sources at v1beta2).
+fn legacy_context() -> String {
+    std::env::var("FLUX9S_LIVE_LEGACY_CONTEXT").unwrap_or_else(|_| "kind-flux9s-legacy".to_string())
+}
+
+async fn client_for(context: &str) -> kube::Client {
+    flux9s::kube::create_client_for_context(context)
+        .await
+        .unwrap_or_else(|e| {
+            panic!("context '{context}' unavailable (run ./scripts/dev-clusters.sh ci): {e}")
+        })
+}
+
+/// Poll `check` every 5s until it yields a value or `timeout_secs` elapses.
+/// Freshly built clusters need time for first reconciliations, so live tests
+/// assert eventual state with a bounded deadline instead of exact timing.
+async fn eventually<T, F, Fut>(what: &str, timeout_secs: u64, mut check: F) -> T
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Option<T>>,
+{
+    let deadline = Instant::now() + Duration::from_secs(timeout_secs);
+    loop {
+        if let Some(value) = check().await {
+            return value;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out after {timeout_secs}s waiting for: {what}"
+        );
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+}
+
+/// #204: a step-based ResourceSet's graph includes its downstream inventory —
+/// the staged-rollout ConfigMaps and Jobs aggregate into a resource group.
+#[tokio::test]
+#[ignore = "requires the kind-flux9s-simple dev cluster"]
+async fn resource_set_graph_shows_inventory() {
+    use flux9s::trace::{NodeType, build_resource_graph};
+
+    let client = client_for(&simple_context()).await;
+
+    let description = eventually("staged-rollout graph resource group", 180, || {
+        let client = client.clone();
+        async move {
+            let graph =
+                build_resource_graph(&client, "ResourceSet", "flux-resources", "staged-rollout")
+                    .await
+                    .ok()?;
+            graph
+                .nodes
+                .iter()
+                .find(|n| n.node_type == NodeType::ResourceGroup)
+                .and_then(|n| n.description.clone())
+        }
+    })
+    .await;
+
+    assert!(
+        description.contains("ConfigMap") && description.contains("Job"),
+        "resource group should aggregate the staged-rollout inventory kinds: {description}"
+    );
+}
+
+/// #191/#193 coupling: the operator's step-failure condition message must
+/// keep the `step "<name>"` format the detail-view phase parser matches.
+/// Catches upstream flux-operator message-format drift.
+#[tokio::test]
+#[ignore = "requires the kind-flux9s-simple dev cluster"]
+async fn step_failure_condition_matches_parser_format() {
+    let client = client_for(&simple_context()).await;
+
+    let message = eventually("staged-rollout-broken step failure", 300, || {
+        let client = client.clone();
+        async move {
+            let obj = flux9s::kube::fetch_resource(
+                &client,
+                "ResourceSet",
+                "flux-resources",
+                "staged-rollout-broken",
+            )
+            .await
+            .ok()?;
+            let conditions = obj.pointer("/status/conditions")?.as_array()?.clone();
+            let ready = conditions
+                .iter()
+                .find(|c| c["type"].as_str() == Some("Ready"))?;
+            if ready["status"].as_str() == Some("False") {
+                ready["message"].as_str().map(String::from)
+            } else {
+                None
+            }
+        }
+    })
+    .await;
+
+    assert!(
+        message.contains("step \"verify\""),
+        "the steps parser matches `step \"<name>\"` in failure messages; \
+         the operator now says: {message}"
+    );
+}
+
+/// #191: describe data for the deliberately broken Kustomization includes
+/// its Warning events (the field-selector fetch path, live).
+#[tokio::test]
+#[ignore = "requires the kind-flux9s-simple dev cluster"]
+async fn broken_kustomization_describe_includes_warning_events() {
+    let client = client_for(&simple_context()).await;
+
+    let events = eventually("broken-path-demo Warning events", 300, || {
+        let client = client.clone();
+        async move {
+            let describe = flux9s::kube::fetch::fetch_describe_data(
+                &client,
+                "Kustomization",
+                "flux-resources",
+                "broken-path-demo",
+            )
+            .await
+            .ok()?;
+            assert!(
+                describe.events_error.is_none(),
+                "events lookup should not fail: {:?}",
+                describe.events_error
+            );
+            if describe.events.iter().any(|e| e.is_warning()) {
+                Some(describe.events)
+            } else {
+                None
+            }
+        }
+    })
+    .await;
+
+    let warning = events.iter().find(|e| e.is_warning()).unwrap();
+    assert_eq!(warning.involved_name, "broken-path-demo");
+    assert!(
+        !warning.message.is_empty(),
+        "warning events carry the reconcile error detail"
+    );
+}
+
+/// #192: the pod log API path used by the `:logs` stream returns lines for a
+/// controller pod (snapshot mode — bounded, no follow).
+#[tokio::test]
+#[ignore = "requires the kind-flux9s-simple dev cluster"]
+async fn controller_log_snapshot_returns_lines() {
+    use futures::{AsyncBufReadExt, TryStreamExt};
+    use k8s_openapi::api::core::v1::Pod;
+    use kube::api::{ListParams, LogParams};
+
+    let client = client_for(&simple_context()).await;
+    let pods: kube::Api<Pod> = kube::Api::namespaced(client, "flux-system");
+
+    let pod_name = eventually("a running source-controller pod", 120, || {
+        let pods = pods.clone();
+        async move {
+            let list = pods
+                .list(&ListParams::default().labels("app=source-controller"))
+                .await
+                .ok()?;
+            list.items.first().and_then(|p| p.metadata.name.clone())
+        }
+    })
+    .await;
+
+    let params = LogParams {
+        tail_lines: Some(20),
+        ..Default::default()
+    };
+    let stream = pods
+        .log_stream(&pod_name, &params)
+        .await
+        .expect("log stream should open for a controller pod");
+    let mut lines = stream.lines();
+    let first = lines
+        .try_next()
+        .await
+        .expect("log stream should be readable");
+    assert!(
+        first.is_some_and(|line| !line.is_empty()),
+        "controller pod should have log output"
+    );
+}
+
+/// Version-fallback discovery against the legacy (Flux 2.2.x) cluster: an
+/// OCIRepository is only served at v1beta2 there, so discovery must fall back
+/// from v1. This is the failure mode that once left all five fallback kinds
+/// silently unwatched — asserting it live keeps the fallback path honest.
+#[tokio::test]
+#[ignore = "requires the kind-flux9s-legacy dev cluster"]
+async fn legacy_sources_resolve_via_version_fallback() {
+    let client = client_for(&legacy_context()).await;
+
+    let api_resource = eventually("OCIRepository v1beta2 fallback discovery", 120, || {
+        let client = client.clone();
+        async move {
+            flux9s::kube::get_api_resource_with_fallback(
+                &client,
+                "OCIRepository",
+                "flux-resources",
+                "podinfo-oci",
+            )
+            .await
+            .ok()
+        }
+    })
+    .await;
+
+    assert_eq!(
+        api_resource.version, "v1beta2",
+        "Flux 2.2.x serves OCIRepository at v1beta2 — discovery must fall back from v1"
+    );
+}


### PR DESCRIPTION
Signed-off-by: Daniel Guns <danbguns@gmail.com>

closes #204

  ### Features

 
  - **ResourceSet/FluxInstance graphs (#204)** — `status.inventory` now renders
    downstream: produced Flux resources become navigable nodes, workloads get
    the status group, and arbitrary kinds (Namespaces, CRDs) aggregate into the
    resource group. One generalized inventory path behind a new
    `FluxResourceKind::has_inventory_downstream()`.

  ### Fixed

  - Graph no longer flashes when the focused node is taller than the viewport
    (FluxInstance workload groups): the focus auto-scroll pinned to a fixed
    point instead of oscillating between frames, with fixed-point regression
    tests.

  ### Dev/test infrastructure

  - Dev clusters refreshed: flux-operator 0.55, Flux 2.9.x + source-watcher on
    `simple`, step-based ResourceSet fixtures (green + deliberately failing),
    ArtifactGenerator, and failure cases feeding the events/logs views; fixed
    dead `${{ }}` template syntax.
  - New live regression suite (`tests/live_tests.rs`, `just test-live`) making
    exact assertions against the kind clusters — including a tripwire for
    upstream flux-operator message-format drift — run weekly / on dispatch by
    the new `live-tests.yml` workflow.
