### PR TITLE
Add an edit option to modify the resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ By default, `flux9s` watches the `flux-system` namespace. Use `:ns all` to view 
 - `r` - Resume resource
 - `R` - Reconcile resource
 - `y` - View resource YAML
+- `e` - Edit resource in system editor (opens YAML, applies changes via Server Side Apply on save)
 - `f` - Toggle favorite
 - `g` - View resource graph (Kustomization, HelmRelease, etc.)
 - `h` - View reconciliation history
@@ -156,6 +157,7 @@ By default, `flux9s` watches the `flux-system` namespace. Use `:ns all` to view 
 - `flux9s config set {KEY} {VALUE}` - set a yaml option with the cli.
 - `config set ui.skinReadOnly rose-pine` - set a skin that is in your systems flux9s/skins dir when readonly enabled.
 - `flux9s config set connectTimeoutSeconds 15` - set the startup Kubernetes API health-check timeout.
+- `flux9s config set editor vim` - set the preferred editor for resource editing (overridden by `FLUX9S_EDITOR` env var).
 - `flux9s config skins set navy.yaml` - import a skin, validate, set in config.
 
 > **Note:** Not all K9s skins are compatible with flux9s. flux9s skins follow a similar format but may require adjustments to work properly.

--- a/justfile
+++ b/justfile
@@ -18,7 +18,7 @@ test:
 
 # Run integration tests
 test-integration:
-    cargo test --test crd_compatibility --test resource_registry --test model_compatibility --test field_extraction --test trace_tests --test graph_tests
+    cargo test --test crd_compatibility --test resource_registry --test model_compatibility --test field_extraction --test trace_tests --test graph_tests --test snapshot_tests
 
 # Run cargo-audit to check for CVEs (ignores unmaintained warnings)
 audit:

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -39,6 +39,7 @@ pub fn get_config_value(config: &schema::Config, key: &str) -> anyhow::Result<St
         }
         "defaultResourceFilter" => Ok(config.default_resource_filter.clone().unwrap_or_default()),
         "connectTimeoutSeconds" => Ok(config.connect_timeout_seconds.to_string()),
+        "editor" => Ok(config.editor.clone().unwrap_or_default()),
         _ => Err(anyhow::anyhow!("Unknown configuration key: {}", key)),
     }
 }
@@ -144,6 +145,13 @@ pub fn set_config_value(config: &mut schema::Config, key: &str, value: &str) -> 
             }
             config.connect_timeout_seconds = seconds;
         }
+        "editor" => {
+            if value.is_empty() {
+                config.editor = None;
+            } else {
+                config.editor = Some(value.to_string());
+            }
+        }
         _ => return Err(anyhow::anyhow!("Unknown configuration key: {}", key)),
     }
 
@@ -174,5 +182,23 @@ mod tests {
         let err = set_config_value(&mut config, "connectTimeoutSeconds", "0").unwrap_err();
 
         assert!(err.to_string().contains("positive integer"));
+    }
+
+    #[test]
+    fn test_editor_get_set_config_value() {
+        let mut config = schema::Config::default();
+
+        // Default is empty string (None)
+        assert_eq!(get_config_value(&config, "editor").unwrap(), "");
+
+        // Set a value
+        set_config_value(&mut config, "editor", "nvim").unwrap();
+        assert_eq!(get_config_value(&config, "editor").unwrap(), "nvim");
+        assert_eq!(config.editor.as_deref(), Some("nvim"));
+
+        // Clear by setting empty string
+        set_config_value(&mut config, "editor", "").unwrap();
+        assert_eq!(get_config_value(&config, "editor").unwrap(), "");
+        assert!(config.editor.is_none());
     }
 }

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -54,6 +54,11 @@ pub struct Config {
     /// `FLUX9S_CONNECT_TIMEOUT` environment variable.
     #[serde(default = "default_connect_timeout_seconds")]
     pub connect_timeout_seconds: u64,
+
+    /// Preferred editor override. Checked after FLUX9S_EDITOR env var,
+    /// before $VISUAL and $EDITOR. Leave unset to use $VISUAL/$EDITOR/vi.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub editor: Option<String>,
 }
 
 /// UI configuration
@@ -120,6 +125,7 @@ impl Default for Config {
             favorites: Vec::new(), // Empty by default
             default_resource_filter: None,
             connect_timeout_seconds: default_connect_timeout_seconds(),
+            editor: None,
         }
     }
 }
@@ -188,5 +194,20 @@ ui:
         assert_eq!(config.default_namespace, "my-ns");
         assert_eq!(config.connect_timeout_seconds, 15);
         assert_eq!(config.ui.skin, "dracula");
+    }
+
+    #[test]
+    fn test_config_without_editor_field_deserializes_as_none() {
+        // Older config files without the editor field should still deserialize fine.
+        let yaml = "readOnly: false\n";
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        assert!(config.editor.is_none());
+    }
+
+    #[test]
+    fn test_config_with_editor_field() {
+        let yaml = "readOnly: false\neditor: nvim\n";
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.editor.as_deref(), Some("nvim"));
     }
 }

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -1,0 +1,228 @@
+//! Editor resolution and launching utilities
+//!
+//! Provides functions to determine which system editor to use and to open
+//! a file in that editor, temporarily suspending the TUI if needed.
+
+/// Build the ordered list of editor candidates from highest to lowest priority.
+///
+/// Priority order:
+/// 1. `FLUX9S_EDITOR` env var
+/// 2. `config_editor` field value
+/// 3. `$VISUAL` env var
+/// 4. `$EDITOR` env var
+/// 5. Fallback: `"vi"`
+pub fn editor_candidates(config_editor: Option<&str>) -> Vec<String> {
+    editor_candidates_with_env(
+        std::env::var("FLUX9S_EDITOR").ok(),
+        config_editor,
+        std::env::var("VISUAL").ok(),
+        std::env::var("EDITOR").ok(),
+    )
+}
+
+/// Pure inner function — returns candidates in priority order, testable without env side effects.
+pub fn editor_candidates_with_env(
+    flux9s_editor: Option<String>,
+    config_editor: Option<&str>,
+    visual: Option<String>,
+    editor: Option<String>,
+) -> Vec<String> {
+    let mut candidates: Vec<String> = Vec::new();
+    if let Some(e) = flux9s_editor.filter(|s| !s.is_empty()) {
+        candidates.push(e);
+    }
+    if let Some(e) = config_editor.filter(|s| !s.is_empty()) {
+        candidates.push(e.to_string());
+    }
+    if let Some(e) = visual.filter(|s| !s.is_empty()) {
+        candidates.push(e);
+    }
+    if let Some(e) = editor.filter(|s| !s.is_empty()) {
+        candidates.push(e);
+    }
+    candidates.push("vi".to_string());
+    // Deduplicate while preserving order
+    let mut seen = std::collections::HashSet::new();
+    candidates.retain(|c| seen.insert(c.clone()));
+    candidates
+}
+
+
+/// Open a file in the given editor, blocking until the editor exits.
+///
+/// Tries each candidate in priority order. If a candidate fails to launch
+/// (not found / not executable), logs a warning and tries the next one.
+/// Returns an error only if every candidate fails.
+pub fn open_in_editor_with_fallback(
+    candidates: &[String],
+    path: &std::path::Path,
+) -> anyhow::Result<()> {
+    let mut last_err = anyhow::anyhow!("No editor candidates available");
+    for editor in candidates {
+        match try_open_editor(editor, path) {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                // Only fall back for "failed to launch" errors, not for the editor
+                // exiting with a non-zero status (that means the user quit with an error).
+                let msg = e.to_string();
+                if msg.contains("Failed to launch") {
+                    tracing::warn!(
+                        "Editor '{}' could not be launched, trying next: {}",
+                        editor,
+                        e
+                    );
+                    last_err = e;
+                } else {
+                    return Err(e);
+                }
+            }
+        }
+    }
+    Err(last_err)
+}
+
+fn try_open_editor(editor: &str, path: &std::path::Path) -> anyhow::Result<()> {
+    use anyhow::Context;
+    let status = std::process::Command::new(editor)
+        .arg(path)
+        .status()
+        .with_context(|| format!("Failed to launch editor '{}'", editor))?;
+    if !status.success() {
+        return Err(anyhow::anyhow!(
+            "Editor '{}' exited with non-zero status: {}",
+            editor,
+            status
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn first(candidates: Vec<String>) -> String {
+        candidates.into_iter().next().unwrap_or_else(|| "vi".to_string())
+    }
+
+    #[test]
+    fn test_resolve_editor_fallback_to_vi() {
+        let result = first(editor_candidates_with_env(None, None, None, None));
+        assert_eq!(result, "vi");
+    }
+
+    #[test]
+    fn test_resolve_editor_flux9s_editor_takes_priority() {
+        let result = first(editor_candidates_with_env(
+            Some("nvim".to_string()),
+            Some("emacs"),
+            Some("vim".to_string()),
+            Some("nano".to_string()),
+        ));
+        assert_eq!(result, "nvim");
+    }
+
+    #[test]
+    fn test_resolve_editor_config_editor_second_priority() {
+        let result = first(editor_candidates_with_env(
+            None,
+            Some("emacs"),
+            Some("vim".to_string()),
+            Some("nano".to_string()),
+        ));
+        assert_eq!(result, "emacs");
+    }
+
+    #[test]
+    fn test_resolve_editor_visual_third_priority() {
+        let result = first(editor_candidates_with_env(
+            None,
+            None,
+            Some("vim".to_string()),
+            Some("nano".to_string()),
+        ));
+        assert_eq!(result, "vim");
+    }
+
+    #[test]
+    fn test_resolve_editor_editor_fourth_priority() {
+        let result = first(editor_candidates_with_env(None, None, None, Some("nano".to_string())));
+        assert_eq!(result, "nano");
+    }
+
+    #[test]
+    fn test_resolve_editor_empty_strings_skipped() {
+        // Empty strings should be treated as "not set"
+        let result = first(editor_candidates_with_env(
+            Some("".to_string()),
+            Some(""),
+            Some("".to_string()),
+            Some("nano".to_string()),
+        ));
+        assert_eq!(result, "nano");
+    }
+
+    #[test]
+    fn test_resolve_editor_config_over_visual_when_flux9s_empty() {
+        let result = first(editor_candidates_with_env(
+            Some("".to_string()),
+            Some("code"),
+            Some("vim".to_string()),
+            None,
+        ));
+        assert_eq!(result, "code");
+    }
+
+    #[test]
+    fn test_editor_candidates_full_chain() {
+        let candidates = editor_candidates_with_env(
+            Some("nvim".to_string()),
+            Some("emacs"),
+            Some("vim".to_string()),
+            Some("nano".to_string()),
+        );
+        assert_eq!(candidates, vec!["nvim", "emacs", "vim", "nano", "vi"]);
+    }
+
+    #[test]
+    fn test_editor_candidates_deduplicates() {
+        // If $EDITOR and vi are both "vi", only one "vi" should appear
+        let candidates =
+            editor_candidates_with_env(None, None, None, Some("vi".to_string()));
+        assert_eq!(candidates, vec!["vi"]);
+    }
+
+    #[test]
+    fn test_editor_candidates_always_ends_with_vi() {
+        let candidates = editor_candidates_with_env(None, None, None, None);
+        assert_eq!(candidates, vec!["vi"]);
+    }
+
+    #[test]
+    fn test_open_in_editor_with_fallback_skips_missing_editor() {
+        use std::io::Write;
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        writeln!(tmp, "test").unwrap();
+        let path = tmp.path().to_path_buf();
+
+        // "this-editor-does-not-exist" should fail to launch; "true" (always succeeds) is the fallback
+        let candidates = vec![
+            "this-editor-does-not-exist".to_string(),
+            "true".to_string(),
+        ];
+        let result = open_in_editor_with_fallback(&candidates, &path);
+        assert!(result.is_ok(), "should fall back to 'true': {:?}", result);
+    }
+
+    #[test]
+    fn test_open_in_editor_with_fallback_errors_when_all_fail() {
+        use std::io::Write;
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        writeln!(tmp, "test").unwrap();
+        let path = tmp.path().to_path_buf();
+
+        let candidates = vec!["editor-does-not-exist-a".to_string()];
+        let result = open_in_editor_with_fallback(&candidates, &path);
+        assert!(result.is_err());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@
 
 pub mod config;
 pub mod constants;
+pub mod editor;
 pub mod kube;
 pub mod models;
 pub mod operations;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@
 mod cli;
 mod config;
 mod constants;
+mod editor;
 mod kube;
 mod models;
 mod operations;

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -781,6 +781,58 @@ impl FluxOperation for ReconcileWithSourceOperation {
     }
 }
 
+/// Apply a full resource YAML via Server Side Apply.
+///
+/// The YAML must include `metadata.resourceVersion` from the original fetch;
+/// the API server will reject (409 Conflict) if the resource was modified
+/// between the fetch and this apply, providing optimistic locking.
+///
+/// Uses `PatchParams::apply("flux9s").force()` so flux9s takes ownership of
+/// fields it manages, but if the resource was modified (resourceVersion mismatch)
+/// the API server returns 409 before field ownership is checked.
+pub async fn apply_resource_yaml(
+    client: &kube::Client,
+    resource_type: &str,
+    namespace: &str,
+    name: &str,
+    yaml_str: &str,
+) -> anyhow::Result<()> {
+    use anyhow::Context as _;
+
+    let mut value: serde_json::Value = serde_yaml::from_str(yaml_str)
+        .context("Failed to parse edited YAML as valid YAML/JSON")?;
+
+    // SSA rejects documents that include managedFields — strip it before applying.
+    if let Some(meta) = value.get_mut("metadata").and_then(|m| m.as_object_mut()) {
+        meta.remove("managedFields");
+    }
+
+    let api = get_resource_api(client, resource_type, namespace, name).await?;
+
+    let params = PatchParams::apply("flux9s").force();
+    api.patch(name, &params, &Patch::Apply(&value))
+        .await
+        .map_err(|e| {
+            // Surface a user-friendly message for 409 Conflict (concurrent modification)
+            let msg = e.to_string();
+            if msg.contains("409") || msg.contains("Conflict") {
+                anyhow::anyhow!(
+                    "Resource was modified by another process — please re-fetch and try again"
+                )
+            } else {
+                anyhow::anyhow!("Failed to apply resource: {}", msg)
+            }
+        })?;
+
+    tracing::info!(
+        "Successfully applied {}/{} in namespace {} via SSA",
+        resource_type,
+        name,
+        namespace
+    );
+    Ok(())
+}
+
 /// Operation registry - holds all available operations
 pub struct OperationRegistry {
     operations: Vec<Box<dyn FluxOperation>>,
@@ -1102,5 +1154,43 @@ mod tests {
         let reconcile_with_source = registry.get_by_keybinding('W').unwrap();
         assert_eq!(reconcile_with_source.name(), "Reconcile with Source");
         assert!(!reconcile_with_source.requires_confirmation());
+    }
+
+    #[test]
+    fn test_apply_resource_yaml_strips_managed_fields_before_parse() {
+        // Verify that managedFields is removed from the document before it would
+        // be sent to the API server (we test the stripping logic in isolation).
+        let yaml_with_managed_fields = r#"
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: my-ks
+  namespace: flux-system
+  resourceVersion: "12345"
+  managedFields:
+    - manager: flux
+      operation: Apply
+spec:
+  interval: 5m
+"#;
+
+        let mut value: serde_json::Value =
+            serde_yaml::from_str(yaml_with_managed_fields).expect("valid yaml");
+
+        // Apply the same stripping logic used in apply_resource_yaml
+        if let Some(meta) = value.get_mut("metadata").and_then(|m| m.as_object_mut()) {
+            meta.remove("managedFields");
+        }
+
+        let meta = value["metadata"].as_object().unwrap();
+        assert!(
+            meta.get("managedFields").is_none(),
+            "managedFields must be stripped before SSA apply"
+        );
+        // resourceVersion must still be present for optimistic locking
+        assert!(
+            meta.get("resourceVersion").is_some(),
+            "resourceVersion must be preserved for conflict detection"
+        );
     }
 }

--- a/src/tui/app/async_ops.rs
+++ b/src/tui/app/async_ops.rs
@@ -4,6 +4,7 @@
 //! tracing, graph building, and resource operations with their result channels.
 
 use super::core::App;
+use super::state::View;
 use crate::watcher::ResourceKey;
 
 /// Request to trace a resource's ownership chain
@@ -18,6 +19,18 @@ pub struct TraceRequest {
     pub client: kube::Client,
     /// Channel to send the trace result back
     pub tx: tokio::sync::oneshot::Sender<anyhow::Result<crate::tui::trace::TraceResult>>,
+}
+
+/// Request to save edited resource YAML via Server Side Apply
+pub struct EditSaveRequest {
+    /// Key of the resource being saved
+    pub resource_key: ResourceKey,
+    /// Full YAML string from the editor (must include resourceVersion for conflict detection)
+    pub yaml_to_apply: String,
+    /// Kubernetes client to use for the SSA patch
+    pub client: kube::Client,
+    /// Channel to send the apply result back
+    pub tx: tokio::sync::oneshot::Sender<anyhow::Result<()>>,
 }
 
 /// Request to execute an operation on a resource
@@ -82,8 +95,16 @@ impl App {
     }
 
     /// Set YAML fetch result
+    ///
+    /// When the current view is `ResourceEdit`, the full JSON is stored in
+    /// `edit_full_yaml` (so the editor loop can use it). For all other views
+    /// the value is stored in `yaml_fetched` as usual.
     pub fn set_yaml_fetched(&mut self, yaml: serde_json::Value) {
-        self.async_state.yaml_fetched = Some(yaml);
+        if self.view_state.current_view == View::ResourceEdit {
+            self.async_state.edit_full_yaml = Some(yaml);
+        } else {
+            self.async_state.yaml_fetched = Some(yaml);
+        }
     }
 
     /// Set YAML fetch error
@@ -297,6 +318,79 @@ impl App {
         None
     }
 
+    /// Trigger the SSA apply if edited YAML is pending.
+    ///
+    /// Returns an [`EditSaveRequest`] when all conditions are met (a kube client
+    /// is present, `edit_save_pending` is set, and no save is already in flight).
+    pub fn trigger_edit_save(&mut self) -> Option<EditSaveRequest> {
+        self.async_state.edit_save_pending.as_ref()?;
+        if self.async_state.edit_save_result_rx.is_some() {
+            return None;
+        }
+        let rk = self.async_state.edit_pending.clone()?;
+        let client = self.kube_client.clone()?;
+        let yaml_to_apply = self.async_state.edit_save_pending.take()?;
+
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.async_state.edit_save_result_rx = Some(rx);
+
+        Some(EditSaveRequest {
+            resource_key: rk,
+            yaml_to_apply,
+            client,
+            tx,
+        })
+    }
+
+    /// Try to get the SSA apply result (non-blocking).
+    pub fn try_get_edit_save_result(&mut self) -> Option<anyhow::Result<()>> {
+        if let Some(ref mut rx) = self.async_state.edit_save_result_rx {
+            match rx.try_recv() {
+                Ok(result) => {
+                    self.async_state.edit_save_result_rx = None;
+                    return Some(result);
+                }
+                Err(tokio::sync::oneshot::error::TryRecvError::Empty) => {
+                    return None;
+                }
+                Err(_) => {
+                    self.async_state.edit_save_result_rx = None;
+                    return Some(Err(anyhow::anyhow!("Edit save failed")));
+                }
+            }
+        }
+        None
+    }
+
+    /// Handle the SSA apply result, updating status and returning to list view on success.
+    pub fn set_edit_save_result(&mut self, result: anyhow::Result<()>) {
+        match result {
+            Ok(_) => {
+                tracing::info!("Resource edit applied successfully via SSA");
+                // Clear all edit state
+                self.async_state.edit_pending = None;
+                self.async_state.edit_full_yaml = None;
+                self.async_state.edit_save_pending = None;
+                self.async_state.edit_error_message = None;
+                self.async_state.edit_editor_launched = false;
+                // Return to previous list view
+                self.view_state.current_view = self.view_state.previous_list_view;
+                self.set_status_message(("Resource saved successfully".to_string(), false));
+            }
+            Err(e) => {
+                tracing::warn!("Resource edit SSA apply failed: {}", e);
+                let msg = e.to_string();
+                self.async_state.edit_error_message = Some(msg.clone());
+                self.async_state.edit_pending = None;
+                self.async_state.edit_full_yaml = None;
+                self.async_state.edit_save_pending = None;
+                self.async_state.edit_editor_launched = false;
+                self.view_state.current_view = self.view_state.previous_list_view;
+                self.set_status_message((format!("Save failed: {}", msg), true));
+            }
+        }
+    }
+
     /// Set operation result and update status message
     pub fn set_operation_result(&mut self, result: anyhow::Result<()>) {
         match result {
@@ -325,5 +419,112 @@ impl App {
                 self.set_status_message((format!("Operation failed: {}", e), true));
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::state::View;
+    use super::*;
+    use crate::config::{Config, UiConfig};
+    use crate::tui::Theme;
+    use crate::watcher::ResourceState;
+    use std::collections::HashMap;
+
+    fn create_test_app() -> App {
+        let state = ResourceState::new();
+        let config = Config {
+            read_only: false,
+            default_namespace: "".to_string(),
+            default_controller_namespace: "".to_string(),
+            namespace_hotkeys: vec![],
+            ui: UiConfig {
+                enable_mouse: false,
+                headless: false,
+                no_icons: false,
+                skin: "default".to_string(),
+                skin_read_only: None,
+                splashless: true,
+            },
+            context_skins: HashMap::new(),
+            cluster: HashMap::new(),
+            favorites: vec![],
+            default_resource_filter: None,
+            connect_timeout_seconds: crate::kube::health::DEFAULT_CONNECT_TIMEOUT_SECS,
+            editor: None,
+        };
+        let theme = Theme::default();
+        App::new(state, "test-context".to_string(), None, config, theme)
+    }
+
+    fn set_edit_in_progress(app: &mut App) {
+        use crate::watcher::ResourceKey;
+        app.async_state.edit_pending = Some(ResourceKey {
+            resource_type: "Kustomization".to_string(),
+            namespace: "flux-system".to_string(),
+            name: "my-ks".to_string(),
+        });
+        app.async_state.edit_full_yaml = Some(serde_json::json!({"apiVersion": "v1"}));
+        app.async_state.edit_save_pending = Some("apiVersion: v1".to_string());
+        app.async_state.edit_editor_launched = true;
+        app.view_state.current_view = View::ResourceEdit;
+        app.view_state.previous_list_view = View::ResourceList;
+    }
+
+    #[test]
+    fn test_set_edit_save_result_success_clears_state_and_returns_to_list() {
+        let mut app = create_test_app();
+        set_edit_in_progress(&mut app);
+
+        app.set_edit_save_result(Ok(()));
+
+        // All edit state cleared
+        assert!(app.async_state.edit_pending.is_none());
+        assert!(app.async_state.edit_full_yaml.is_none());
+        assert!(app.async_state.edit_save_pending.is_none());
+        assert!(app.async_state.edit_error_message.is_none());
+        assert!(!app.async_state.edit_editor_launched);
+        // Returns to list view
+        assert_eq!(app.view_state.current_view, View::ResourceList);
+        // Shows success status
+        let (msg, is_error) = app.ui_state.status_message.as_ref().unwrap();
+        assert!(!is_error, "success result should not be an error message");
+        assert!(msg.contains("saved"), "success message should mention 'saved'");
+    }
+
+    #[test]
+    fn test_set_edit_save_result_error_clears_state_and_returns_to_list() {
+        let mut app = create_test_app();
+        set_edit_in_progress(&mut app);
+
+        app.set_edit_save_result(Err(anyhow::anyhow!("conflict: resource was modified")));
+
+        // All edit state cleared even on error
+        assert!(app.async_state.edit_pending.is_none());
+        assert!(app.async_state.edit_full_yaml.is_none());
+        assert!(app.async_state.edit_save_pending.is_none());
+        assert!(!app.async_state.edit_editor_launched);
+        // Error message stored
+        assert!(app.async_state.edit_error_message.is_some());
+        // Returns to list view (not stuck on ResourceEdit)
+        assert_eq!(app.view_state.current_view, View::ResourceList);
+        // Shows error status
+        let (msg, is_error) = app.ui_state.status_message.as_ref().unwrap();
+        assert!(is_error, "error result should set is_error=true");
+        assert!(
+            msg.contains("conflict"),
+            "error message should propagate the error text"
+        );
+    }
+
+    #[test]
+    fn test_set_edit_save_result_error_returns_to_favorites_if_that_was_previous_view() {
+        let mut app = create_test_app();
+        set_edit_in_progress(&mut app);
+        app.view_state.previous_list_view = View::ResourceFavorites;
+
+        app.set_edit_save_result(Err(anyhow::anyhow!("some error")));
+
+        assert_eq!(app.view_state.current_view, View::ResourceFavorites);
     }
 }

--- a/src/tui/app/core.rs
+++ b/src/tui/app/core.rs
@@ -692,6 +692,7 @@ mod tests {
             favorites: vec![],
             default_resource_filter: None,
             connect_timeout_seconds: crate::kube::health::DEFAULT_CONNECT_TIMEOUT_SECS,
+            editor: None,
         };
         let theme = Theme::default();
         App::new(state, "test-context".to_string(), None, config, theme)

--- a/src/tui/app/events.rs
+++ b/src/tui/app/events.rs
@@ -117,6 +117,7 @@ impl App {
                     | crossterm::event::KeyCode::Char('r')
                     | crossterm::event::KeyCode::Char('R')
                     | crossterm::event::KeyCode::Char('W')
+                    | crossterm::event::KeyCode::Char('e')
             ) | (
                 crossterm::event::KeyModifiers::CONTROL,
                 crossterm::event::KeyCode::Char('d')
@@ -443,6 +444,42 @@ impl App {
                     self.view_state.current_view = View::ResourceDescribe;
                 }
             }
+            crossterm::event::KeyCode::Char('e') => {
+                if self.config.read_only {
+                    self.set_status_message((
+                        "Editing disabled in read-only mode".to_string(),
+                        true,
+                    ));
+                } else if let Some(resource) = self.get_current_resource() {
+                    // Save current view as previous list view before navigating
+                    if self.view_state.current_view == View::ResourceList
+                        || self.view_state.current_view == View::ResourceFavorites
+                    {
+                        self.view_state.previous_list_view = self.view_state.current_view;
+                    }
+                    // Trigger YAML fetch for the full resource object
+                    let fetch_key = format!(
+                        "{}:{}:{}",
+                        resource.resource_type, resource.namespace, resource.name
+                    );
+                    self.async_state.yaml_fetch_pending = Some(fetch_key);
+                    self.async_state.yaml_fetched = None;
+                    self.async_state.edit_pending = Some(ResourceKey::new(
+                        resource.resource_type.clone(),
+                        resource.namespace.clone(),
+                        resource.name.clone(),
+                    ));
+                    self.async_state.edit_full_yaml = None;
+                    self.async_state.edit_editor_launched = false;
+                    self.async_state.edit_error_message = None;
+                    self.view_state.current_view = View::ResourceEdit;
+                } else {
+                    self.set_status_message((
+                        "No resource selected for editing".to_string(),
+                        true,
+                    ));
+                }
+            }
             crossterm::event::KeyCode::Enter
                 if (self.view_state.current_view == View::ResourceList
                     || self.view_state.current_view == View::ResourceFavorites) =>
@@ -592,6 +629,15 @@ impl App {
                     // Return to previous list view (favorites if we came from there, otherwise list)
                     self.view_state.current_view = self.view_state.previous_list_view;
                     self.selection_state.selected_resource_key = None;
+                } else if self.view_state.current_view == View::ResourceEdit {
+                    // Cancel edit — clear all edit state
+                    self.async_state.edit_pending = None;
+                    self.async_state.edit_full_yaml = None;
+                    self.async_state.edit_save_pending = None;
+                    self.async_state.edit_save_result_rx = None;
+                    self.async_state.edit_error_message = None;
+                    self.async_state.edit_editor_launched = false;
+                    self.view_state.current_view = self.view_state.previous_list_view;
                 } else if self.view_state.current_view == View::ResourceFavorites {
                     self.view_state.current_view = View::ResourceList;
                     self.selection_state.selected_resource_key = None;
@@ -779,6 +825,17 @@ impl App {
                 // there, otherwise the main resource list).
                 self.view_state.current_view = self.view_state.previous_list_view;
                 self.selection_state.selected_resource_key = None;
+                None
+            }
+            View::ResourceEdit => {
+                // Cancel edit — clear all edit state and return to list
+                self.async_state.edit_pending = None;
+                self.async_state.edit_full_yaml = None;
+                self.async_state.edit_save_pending = None;
+                self.async_state.edit_save_result_rx = None;
+                self.async_state.edit_error_message = None;
+                self.async_state.edit_editor_launched = false;
+                self.view_state.current_view = self.view_state.previous_list_view;
                 None
             }
             View::ResourceFavorites => {
@@ -1399,6 +1456,7 @@ mod tests {
             favorites: vec![],
             default_resource_filter: None,
             connect_timeout_seconds: crate::kube::health::DEFAULT_CONNECT_TIMEOUT_SECS,
+            editor: None,
         };
         let theme = Theme::default();
         App::new(state, "test-context".to_string(), None, config, theme)

--- a/src/tui/app/mod.rs
+++ b/src/tui/app/mod.rs
@@ -5,7 +5,7 @@
 
 pub mod state;
 
-mod async_ops;
+pub mod async_ops;
 mod core;
 mod events;
 mod rendering;

--- a/src/tui/app/rendering.rs
+++ b/src/tui/app/rendering.rs
@@ -497,6 +497,19 @@ impl App {
                         f.render_widget(paragraph, area);
                     }
                 }
+                View::ResourceEdit => {
+                    let msg = if self.async_state.edit_save_result_rx.is_some() {
+                        "Saving changes..."
+                    } else if self.async_state.edit_editor_launched {
+                        "Editing in external editor..."
+                    } else {
+                        "Loading resource..."
+                    };
+                    let paragraph = Paragraph::new(msg)
+                        .alignment(ratatui::layout::Alignment::Center)
+                        .block(Block::default().borders(Borders::ALL).title("Edit"));
+                    f.render_widget(paragraph, area);
+                }
                 View::Help => {
                     render_help(f, area, &self.theme, self.namespace_hotkeys());
                 }

--- a/src/tui/app/state.rs
+++ b/src/tui/app/state.rs
@@ -18,6 +18,8 @@ pub enum View {
     ResourceGraph,
     ResourceFavorites,
     ResourceHistory,
+    /// Waiting for external editor / SSA apply
+    ResourceEdit,
     #[allow(dead_code)] // Reserved for future alternative help view implementation
     Help,
 }
@@ -203,6 +205,20 @@ pub struct AsyncOperationState {
     pub operation_result_rx: Option<tokio::sync::oneshot::Receiver<anyhow::Result<()>>>,
     pub last_operation_key: Option<char>,
     pub confirmation_pending: Option<PendingOperation>,
+
+    // Edit operation
+    /// Resource being edited (key used for SSA apply)
+    pub edit_pending: Option<ResourceKey>,
+    /// Full fetched JSON object (includes resourceVersion) for the resource being edited
+    pub edit_full_yaml: Option<serde_json::Value>,
+    /// YAML string from the editor — queued for SSA apply
+    pub edit_save_pending: Option<String>,
+    /// Receiver for the async SSA apply result
+    pub edit_save_result_rx: Option<tokio::sync::oneshot::Receiver<anyhow::Result<()>>>,
+    /// Error message from the last failed save attempt
+    pub edit_error_message: Option<String>,
+    /// True once the external editor has been launched for the current edit
+    pub edit_editor_launched: bool,
 }
 
 impl AsyncOperationState {
@@ -227,6 +243,13 @@ impl AsyncOperationState {
         self.operation_result_rx = None;
         self.last_operation_key = None;
         self.confirmation_pending = None;
+
+        self.edit_pending = None;
+        self.edit_full_yaml = None;
+        self.edit_save_pending = None;
+        self.edit_save_result_rx = None;
+        self.edit_error_message = None;
+        self.edit_editor_launched = false;
     }
 }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -548,9 +548,114 @@ pub async fn run_tui_with_async_init(
                 Err(e) => {
                     tracing::debug!("YAML fetch error result received: {}", e);
                     app.set_yaml_fetch_error();
+                    // If we were trying to edit, cancel the edit view on error
+                    if app.view_state.current_view == crate::tui::app::state::View::ResourceEdit {
+                        app.async_state.edit_pending = None;
+                        app.async_state.edit_editor_launched = false;
+                        app.view_state.current_view = app.view_state.previous_list_view;
+                    }
                     app.set_status_message((format!("Failed to fetch YAML: {}", e), true));
                 }
             }
+        }
+
+        // If we have a full YAML ready for editing, launch the system editor synchronously.
+        // This must run on the main thread (not in tokio::spawn) so we can properly
+        // suspend and resume the TUI terminal state.
+        if app.view_state.current_view == crate::tui::app::state::View::ResourceEdit
+            && app.async_state.edit_full_yaml.is_some()
+            && app.async_state.edit_save_pending.is_none()
+            && app.async_state.edit_save_result_rx.is_none()
+            && !app.async_state.edit_editor_launched
+        {
+            app.async_state.edit_editor_launched = true;
+
+            if let Some(full_yaml_json) = app.async_state.edit_full_yaml.take() {
+                let yaml_str = serde_yaml::to_string(&full_yaml_json)
+                    .unwrap_or_else(|_| "{}".to_string());
+                let editor_candidates =
+                    crate::editor::editor_candidates(app.config.editor.as_deref());
+                let enable_mouse = app.config.ui.enable_mouse;
+
+                // Suspend TUI: leave raw mode and alternate screen so the editor
+                // can take over the terminal normally.
+                disable_raw_mode()?;
+                execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+                if enable_mouse {
+                    execute!(terminal.backend_mut(), DisableMouseCapture)?;
+                }
+
+                let edit_result: anyhow::Result<Option<String>> = (|| {
+                    let mut tmp = tempfile::NamedTempFile::new()?;
+                    use std::io::Write;
+                    tmp.write_all(yaml_str.as_bytes())?;
+                    let tmp_path = tmp.path().to_path_buf();
+
+                    crate::editor::open_in_editor_with_fallback(&editor_candidates, &tmp_path)?;
+
+                    let edited = std::fs::read_to_string(&tmp_path)?;
+                    // Return None if content is unchanged
+                    if edited.trim() == yaml_str.trim() {
+                        Ok(None)
+                    } else {
+                        Ok(Some(edited))
+                    }
+                })();
+
+                // Re-enter TUI: restore raw mode and alternate screen.
+                enable_raw_mode()?;
+                execute!(io::stdout(), EnterAlternateScreen)?;
+                if enable_mouse {
+                    execute!(io::stdout(), EnableMouseCapture)?;
+                }
+                terminal.clear()?;
+
+                match edit_result {
+                    Ok(Some(edited_yaml)) => {
+                        app.async_state.edit_save_pending = Some(edited_yaml);
+                    }
+                    Ok(None) => {
+                        // No change — cancel edit and return to list
+                        app.set_status_message((
+                            "Edit cancelled (no changes)".to_string(),
+                            false,
+                        ));
+                        app.async_state.edit_full_yaml = None;
+                        app.async_state.edit_pending = None;
+                        app.async_state.edit_editor_launched = false;
+                        app.view_state.current_view = app.view_state.previous_list_view;
+                    }
+                    Err(e) => {
+                        app.set_status_message((format!("Editor error: {}", e), true));
+                        app.async_state.edit_full_yaml = None;
+                        app.async_state.edit_pending = None;
+                        app.async_state.edit_editor_launched = false;
+                        app.view_state.current_view = app.view_state.previous_list_view;
+                    }
+                }
+            }
+        }
+
+        // Check if we need to apply edited YAML via Server Side Apply
+        if kube_initialized {
+            if let Some(req) = app.trigger_edit_save() {
+                tokio::spawn(async move {
+                    let result = crate::operations::apply_resource_yaml(
+                        &req.client,
+                        &req.resource_key.resource_type,
+                        &req.resource_key.namespace,
+                        &req.resource_key.name,
+                        &req.yaml_to_apply,
+                    )
+                    .await;
+                    let _ = req.tx.send(result);
+                });
+            }
+        }
+
+        // Check for SSA apply results
+        if let Some(result) = app.try_get_edit_save_result() {
+            app.set_edit_save_result(result);
         }
 
         // Check for describe fetch results

--- a/tests/snapshot_tests.rs
+++ b/tests/snapshot_tests.rs
@@ -40,6 +40,7 @@ fn create_test_config() -> Config {
         favorites: vec![],
         default_resource_filter: None,
         connect_timeout_seconds: flux9s::kube::health::DEFAULT_CONNECT_TIMEOUT_SECS,
+        editor: None,
     }
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing! A few things that make review fast: -->

## What does this PR do?

 Resource editing via system editor (e)

 Adds the ability to edit any Flux resource directly from the TUI, k9s-style.

## Checklist

- [ x] `just ci` passes locally (fmt, clippy, audit, tests)
- [ x] Commits are signed off (`git commit -s`) — the DCO check requires it
- [ x] New behavior has tests
- [ x] User-facing changes update the help view, README, and docs site as applicable

<!-- See CONTRIBUTING.md and DEVELOPER_GUIDE.md for setup and conventions. -->

---

  How it works

  Press e on any resource (requires readOnly: false). The TUI suspends, your system editor opens with the resource YAML, and on save the changes are applied to the cluster via Server Side Apply. The
  resourceVersion field is preserved so the API server will reject a stale edit with a 409 if another process modified the resource in the meantime.

  Key details

  - Editor resolution — FLUX9S_EDITOR → config.editor → $VISUAL → $EDITOR → vi. If the configured editor can't be launched (e.g. not installed), it warns and falls through to the next candidate automatically.
  - managedFields stripping — stripped from metadata before the patch; SSA rejects documents that include it (400).
  - Terminal lifecycle — raw mode and alternate screen are suspended before spawning the editor and restored after exit.
  - No-op on unchanged content — if the file is unmodified on exit, the edit is silently cancelled.
  - Error recovery — on save failure (validation error, conflict, etc.) the error appears in the footer and the view returns to the resource list automatically with all edit state cleared.

  New config key

  flux9s config set editor vim     # persist preferred editor
  FLUX9S_EDITOR=vim flux9s         # override per-session (highest priority)

  Files changed

  - src/editor.rs — new; editor candidate resolution and fallback launch logic
  - src/operations.rs — apply_resource_yaml(): SSA apply with managedFields stripping
  - src/config/schema.rs — added editor: Option<String> field
  - src/config/mod.rs — get/set support for the editor config key
  - src/tui/app/state.rs — ResourceEdit view variant; 6 edit-state fields on AsyncOperationState
  - src/tui/app/async_ops.rs — trigger_edit_save, try_get_edit_save_result, set_edit_save_result
  - src/tui/app/events.rs — e keybinding (gated on !read_only); Esc cancels an in-progress edit
  - src/tui/app/rendering.rs — ResourceEdit render arm (loading / editing / saving states)
  - src/tui/mod.rs — editor launch block, SSA trigger and result polling
  - README.md — documents the e keybinding and editor config key

  Tests added

  - src/editor.rs — full precedence chain, deduplication, fallback-on-launch-failure
  - src/tui/app/async_ops.rs — set_edit_save_result success and error paths (state cleared, correct view restored)
  - src/operations.rs — managedFields stripping preserves resourceVersion


