### PR TITLE
ns removed from top menu - new picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ A [K9s](https://github.com/derailed/k9s)-inspired terminal UI for monitoring Flu
 
 `flux9s` provides a terminal-based interface for monitoring and managing Flux CD resources, inspired by the excellent [K9s](https://github.com/derailed/k9s) project. It offers real-time monitoring of Flux Custom Resources (CRDs) including Kustomizations, GitRepositories, HelmReleases, and more.
 
+> flux9s is listed as a community UI in the [Flux ecosystem](https://fluxcd.io/ecosystem/#flux-uis--guis).
+
 ### Features
 
 - **Real-time monitoring** - Watch Flux resources as they change using Kubernetes Watch API

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -81,6 +81,7 @@ notoc: true
       <h2>What flux9s is</h2>
       <p><code>flux9s</code> is a terminal UI for operators who want live visibility into Flux resources and the cluster state around them without leaving the shell. It watches Flux resources in real time, keeps a local in-memory view of their current state, and lets you move quickly between lists, details, YAML, traces, graphs, and reconciliation history.</p>
       <p>The project is intentionally keyboard-first and closely follows familiar <a href="https://github.com/derailed/k9s" target="_blank" rel="noopener noreferrer">K9s</a> patterns: <code>j</code>/<code>k</code> navigation, <code>:</code> command mode, context and namespace switching, footer help, and k9s-style skins.</p>
+      <p>flux9s is listed as a community UI in the <a href="https://fluxcd.io/ecosystem/#flux-uis--guis" target="_blank" rel="noopener noreferrer">Flux ecosystem</a>.</p>
 
       <h2>The problem it solves</h2>
       <p>Flux already provides strong controller APIs, and the <a href="https://fluxoperator.dev/web-ui/" target="_blank" rel="noopener noreferrer">Flux Operator Web UI</a> is an excellent browser-based experience for dashboards and cluster-wide visibility. <code>flux9s</code> was built to complement that workflow, not replace it.</p>

--- a/docs/content/configuration/_index.md
+++ b/docs/content/configuration/_index.md
@@ -184,6 +184,8 @@ The timeout must be a positive integer. The default is `10` seconds.
 
 Bind namespaces to number keys 0–9 for quick switching. If left empty, flux9s auto-discovers namespaces that contain Flux resources at startup.
 
+The assigned hotkeys are listed in the help overlay (press `?`). For interactive, searchable namespace switching, use the `:ns` command, which opens a picker seeded from these namespaces.
+
 **Via command line:**
 
 ```bash

--- a/docs/content/user-guide/_index.md
+++ b/docs/content/user-guide/_index.md
@@ -88,6 +88,7 @@ Type these commands in command mode (press `:`):
 | `:ctx <name>`      | Switch to a different Kubernetes context |
 | `:ctx`             | Open interactive context selection menu  |
 | `:context <name>`  | Alias for `:ctx <name>`                  |
+| `:ns`              | Open interactive namespace picker menu   |
 | `:ns <namespace>`  | Switch to a specific namespace           |
 | `:namespace <ns>`  | Alias for `:ns <namespace>`              |
 | `:ns all`          | View all namespaces                      |

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -45,12 +45,6 @@ pub const MIN_FOOTER_HEIGHT: u16 = 3;
 /// Maximum number of namespace hotkeys (0-9)
 pub const MAX_NAMESPACE_HOTKEYS: usize = 10;
 
-/// Maximum number of namespace hotkeys to display in footer
-pub const MAX_FOOTER_NAMESPACE_HOTKEYS: usize = 3;
-
-/// Maximum namespace name length to display in footer (truncate if longer)
-pub const MAX_FOOTER_NAMESPACE_LENGTH: usize = 8;
-
 /// Splash screen display duration in milliseconds
 pub const SPLASH_DISPLAY_MS: u64 = 1500;
 

--- a/src/tui/app/core.rs
+++ b/src/tui/app/core.rs
@@ -208,6 +208,26 @@ impl App {
         &self.namespace_hotkeys
     }
 
+    /// Namespace options for the `:ns` picker submenu.
+    ///
+    /// Always offers `all` (cluster-wide) first, followed by the discovered /
+    /// configured hotkey namespaces, and guarantees the currently watched
+    /// namespace is selectable even when it is not among the hotkeys.
+    pub fn namespace_picker_options(&self) -> Vec<String> {
+        let mut options = vec!["all".to_string()];
+        for ns in &self.namespace_hotkeys {
+            if ns != "all" && !options.contains(ns) {
+                options.push(ns.clone());
+            }
+        }
+        if let Some(current) = &self.namespace {
+            if !options.contains(current) {
+                options.push(current.clone());
+            }
+        }
+        options
+    }
+
     /// Invalidate the cached layout dimensions, forcing recalculation on next render.
     /// Call this when filter state or resource counts change (anything that affects header height).
     pub(crate) fn invalidate_layout_cache(&mut self) {

--- a/src/tui/app/events.rs
+++ b/src/tui/app/events.rs
@@ -918,6 +918,14 @@ impl App {
                                 format!("Switching to context '{}'...", value),
                                 false,
                             ));
+                        } else if command == "ns" {
+                            // Namespace picker: "all" watches every namespace.
+                            let new_namespace = if value == "all" {
+                                None
+                            } else {
+                                Some(value.clone())
+                            };
+                            self.switch_namespace(new_namespace);
                         } else if command == "logs" {
                             self.open_log_view(&value);
                         } else if command == "pod-logs" {
@@ -1719,15 +1727,32 @@ impl App {
     }
 
     /// `:ns [name|all]` — switch the watched namespace, restarting watchers.
+    ///
+    /// Without an argument, opens the searchable namespace picker submenu;
+    /// `:ns <name>` (or `:ns all` / `:ns -A`) switches directly.
     fn cmd_switch_namespace(&mut self, cmd: &str) {
         let ns = commands::extract_command_arg(cmd, "namespace")
             .or_else(|| commands::extract_command_arg(cmd, "ns"));
-        let new_namespace = match ns.as_deref() {
-            Some("all") | Some("-A") => None,
-            Some(name) => Some(name.to_string()),
-            None => return, // Showing the current namespace: nothing to do.
-        };
+        match ns.as_deref() {
+            Some("all") | Some("-A") => self.switch_namespace(None),
+            Some(name) => self.switch_namespace(Some(name.to_string())),
+            None => {
+                // No argument: open the searchable picker (same reusable submenu
+                // as :ctx / :skin) instead of listing options in the bars.
+                let options = self.namespace_picker_options();
+                match commands::namespace_submenu(&options, &self.namespace) {
+                    Some(submenu) => self.view_state.submenu_state = Some(submenu),
+                    None => {
+                        self.set_status_message(("No namespaces discovered yet".to_string(), true))
+                    }
+                }
+            }
+        }
+    }
 
+    /// Switch the watched namespace, restarting watchers. `None` watches all
+    /// namespaces. Shared by `:ns <name>` and the namespace picker submenu.
+    fn switch_namespace(&mut self, new_namespace: Option<String>) {
         if self.namespace != new_namespace {
             self.namespace = new_namespace.clone();
 
@@ -2852,6 +2877,50 @@ mod tests {
             View::WorkloadDetail,
             "Enter shows the detail; it must not jump into logs"
         );
+    }
+
+    #[test]
+    fn ns_command_without_arg_opens_picker_and_selects() {
+        let mut app = create_test_app(false);
+        // Default hotkeys (no config, no discovery) are ["all", "flux-system"].
+        app.ui_state.command_buffer = "ns".to_string();
+        app.execute_command();
+
+        let submenu = app
+            .view_state
+            .submenu_state
+            .as_ref()
+            .expect(":ns with no argument opens the namespace picker");
+        assert_eq!(submenu.command, "ns");
+        assert_eq!(submenu.items[0].value, "all");
+        assert!(
+            submenu.items.iter().any(|i| i.value == "flux-system"),
+            "picker offers the discovered/hotkey namespaces"
+        );
+
+        // Selecting a namespace switches to it and closes the submenu.
+        app.handle_key(make_key(KeyCode::Char('j'))); // -> flux-system
+        app.handle_key(make_key(KeyCode::Enter));
+        assert!(app.view_state.submenu_state.is_none());
+        assert_eq!(app.namespace, Some("flux-system".to_string()));
+    }
+
+    #[test]
+    fn ns_command_with_arg_switches_directly_without_picker() {
+        let mut app = create_test_app(false);
+        app.ui_state.command_buffer = "ns kube-system".to_string();
+        app.execute_command();
+
+        assert!(
+            app.view_state.submenu_state.is_none(),
+            ":ns <name> switches directly, no picker"
+        );
+        assert_eq!(app.namespace, Some("kube-system".to_string()));
+
+        // `:ns all` returns to the cluster-wide scope.
+        app.ui_state.command_buffer = "ns all".to_string();
+        app.execute_command();
+        assert_eq!(app.namespace, None);
     }
 
     #[test]

--- a/src/tui/app/rendering.rs
+++ b/src/tui/app/rendering.rs
@@ -132,12 +132,8 @@ impl App {
             self.ui_state.cached_header_height = (content_lines + 2).max(MIN_HEADER_HEIGHT);
 
             // Calculate footer height using centralized function
-            self.ui_state.cached_footer_height = calculate_footer_height(
-                terminal_width,
-                self.namespace_hotkeys(),
-                self.namespace(),
-                self.has_connection_error(),
-            );
+            self.ui_state.cached_footer_height =
+                calculate_footer_height(terminal_width, self.has_connection_error());
         }
 
         let header_height = self.ui_state.cached_header_height;
@@ -203,7 +199,6 @@ impl App {
                 self.config.read_only,
                 &self.theme,
                 self.config.ui.no_icons,
-                self.namespace_hotkeys(),
             );
         }
         self.render_main(f, chunks[1]);
@@ -223,8 +218,6 @@ impl App {
             &self.operation_registry,
             &self.state,
             &self.theme,
-            self.namespace_hotkeys(),
-            &self.namespace,
             self.has_connection_error(),
         );
     }

--- a/src/tui/commands.rs
+++ b/src/tui/commands.rs
@@ -409,6 +409,40 @@ pub fn logs_submenu(
     )
 }
 
+/// Build the namespace picker submenu for `:ns` / `:namespace` (no argument).
+///
+/// Lists the selectable namespaces, with `all` for the cluster-wide scope, and
+/// marks the currently watched one. Returns None when there is nothing to pick
+/// from. Uses the same reusable, searchable submenu as `:ctx` and `:skin`.
+pub fn namespace_submenu(namespaces: &[String], current: &Option<String>) -> Option<SubmenuState> {
+    if namespaces.is_empty() {
+        return None;
+    }
+
+    let items: Vec<SubmenuItem> = namespaces
+        .iter()
+        .map(|ns| {
+            let is_current = if ns == "all" {
+                current.is_none()
+            } else {
+                current.as_deref() == Some(ns.as_str())
+            };
+            let display = if is_current {
+                format!("{} (current)", ns)
+            } else {
+                ns.clone()
+            };
+            SubmenuItem::with_display(ns.clone(), display)
+        })
+        .collect();
+
+    Some(
+        SubmenuState::new("ns".to_string(), items)
+            .with_title("Select Namespace".to_string())
+            .with_help("j/k: Navigate | /: Filter | Enter: Select | Esc: Cancel".to_string()),
+    )
+}
+
 /// Returns None if the command doesn't support submenus or if an argument was provided.
 pub fn get_command_submenu(
     cmd: &str,
@@ -599,6 +633,36 @@ mod tests {
             ready,
             version: None,
         }
+    }
+
+    #[test]
+    fn test_namespace_submenu_marks_current_and_all() {
+        assert!(
+            namespace_submenu(&[], &None).is_none(),
+            "no namespaces means no submenu"
+        );
+
+        let namespaces = vec![
+            "all".to_string(),
+            "flux-system".to_string(),
+            "cert-manager".to_string(),
+        ];
+
+        // A specific namespace is current: it is marked, "all" is not.
+        let current = Some("flux-system".to_string());
+        let submenu = namespace_submenu(&namespaces, &current).expect("namespaces make a submenu");
+        assert_eq!(submenu.command, "ns");
+        assert_eq!(submenu.title, Some("Select Namespace".to_string()));
+        // Values stay the bare namespace names for the :ns dispatch.
+        assert_eq!(submenu.items[0].value, "all");
+        assert_eq!(submenu.items[1].value, "flux-system");
+        assert!(!submenu.items[0].display_text.contains("(current)"));
+        assert!(submenu.items[1].display_text.contains("(current)"));
+
+        // Cluster-wide scope (None) marks "all" as current.
+        let submenu = namespace_submenu(&namespaces, &None).unwrap();
+        assert!(submenu.items[0].display_text.contains("(current)"));
+        assert!(!submenu.items[1].display_text.contains("(current)"));
     }
 
     #[test]

--- a/src/tui/keybindings.rs
+++ b/src/tui/keybindings.rs
@@ -108,49 +108,17 @@ pub fn get_resource_help_commands() -> Vec<(&'static str, &'static str)> {
         .collect()
 }
 
-/// Calculate footer height based on navigation segments and namespace hotkeys
+/// Calculate footer height based on navigation segments
 ///
 /// This function uses the exact same logic as `render_navigation_footer` in footer.rs
 /// to ensure consistent height calculations.
-pub fn calculate_footer_height(
-    terminal_width: u16,
-    namespace_hotkeys: &[String],
-    current_namespace: &Option<String>,
-    has_connection_error: bool,
-) -> u16 {
-    use crate::tui::constants::{MAX_FOOTER_NAMESPACE_HOTKEYS, MAX_FOOTER_NAMESPACE_LENGTH};
-
+pub fn calculate_footer_height(terminal_width: u16, has_connection_error: bool) -> u16 {
     // Get base navigation commands
-    let mut nav_segments = if has_connection_error {
+    let nav_segments = if has_connection_error {
         navigation_commands_to_segments_simple(&get_connection_error_commands())
     } else {
         navigation_commands_to_segments_simple(&get_navigation_commands())
     };
-
-    // Add namespace hotkeys (matching footer.rs logic)
-    if !has_connection_error && !namespace_hotkeys.is_empty() {
-        for (idx, ns) in namespace_hotkeys
-            .iter()
-            .take(MAX_FOOTER_NAMESPACE_HOTKEYS)
-            .enumerate()
-        {
-            let display_ns = if ns == "all" {
-                "all".to_string()
-            } else if ns.len() > MAX_FOOTER_NAMESPACE_LENGTH {
-                ns[..MAX_FOOTER_NAMESPACE_LENGTH].to_string()
-            } else {
-                ns.clone()
-            };
-            let label = if (ns == "all" && current_namespace.is_none())
-                || current_namespace.as_ref() == Some(ns)
-            {
-                format!("NS:{}*", display_ns)
-            } else {
-                format!("NS:{}", display_ns)
-            };
-            nav_segments.push((idx.to_string(), label));
-        }
-    }
 
     let footer_available_width = terminal_width.saturating_sub(2); // Account for borders
 
@@ -200,14 +168,14 @@ mod tests {
     #[test]
     fn test_calculate_footer_height_connection_error() {
         // Under a connection error state, the footer has fewer options and fits on one line.
-        let height = calculate_footer_height(80, &[], &None, true);
+        let height = calculate_footer_height(80, true);
         assert_eq!(height, 3); // 1 content line + 2 borders
     }
 
     #[test]
     fn test_calculate_footer_height_normal() {
         // Under normal circumstances, check that it calculates correctly.
-        let height = calculate_footer_height(80, &[], &None, false);
+        let height = calculate_footer_height(80, false);
         // Normally at 80 cols, the default commands (lots of them) wrap to 2 lines.
         assert_eq!(height, 4); // 2 content lines + 2 borders
     }

--- a/src/tui/views/footer.rs
+++ b/src/tui/views/footer.rs
@@ -31,8 +31,6 @@ pub fn render_footer(
     operation_registry: &OperationRegistry,
     state: &ResourceState,
     theme: &Theme,
-    namespace_hotkeys: &[String],
-    current_namespace: &Option<String>,
     has_connection_error: bool,
 ) -> usize {
     if command_mode {
@@ -55,14 +53,7 @@ pub fn render_footer(
 
     // Handle default navigation footer (wrapped for smaller screens)
     if !show_help && confirmation_pending.is_none() && status_message.is_none() {
-        return render_navigation_footer(
-            f,
-            area,
-            theme,
-            namespace_hotkeys,
-            current_namespace,
-            has_connection_error,
-        );
+        return render_navigation_footer(f, area, theme, has_connection_error);
     }
 
     // Build footer text for non-default cases
@@ -190,8 +181,6 @@ fn render_navigation_footer(
     f: &mut Frame,
     area: Rect,
     theme: &Theme,
-    namespace_hotkeys: &[String],
-    current_namespace: &Option<String>,
     has_connection_error: bool,
 ) -> usize {
     // Default navigation hints - wrap for smaller screens
@@ -202,42 +191,7 @@ fn render_navigation_footer(
     } else {
         get_navigation_commands()
     };
-    let mut nav_segments = navigation_commands_to_segments(&commands, theme.footer_key);
-
-    // Add namespace hotkeys (show first few that fit)
-    use crate::tui::constants::{MAX_FOOTER_NAMESPACE_HOTKEYS, MAX_FOOTER_NAMESPACE_LENGTH};
-    if !has_connection_error && !namespace_hotkeys.is_empty() {
-        // Show up to MAX_FOOTER_NAMESPACE_HOTKEYS namespace hotkeys in footer
-        for (idx, ns) in namespace_hotkeys
-            .iter()
-            .take(MAX_FOOTER_NAMESPACE_HOTKEYS)
-            .enumerate()
-        {
-            let key = idx.to_string();
-            let display_ns = if ns == "all" {
-                "all".to_string()
-            } else {
-                // Truncate long namespace names
-                if ns.len() > MAX_FOOTER_NAMESPACE_LENGTH {
-                    ns[..MAX_FOOTER_NAMESPACE_LENGTH].to_string()
-                } else {
-                    ns.clone()
-                }
-            };
-            // Highlight current namespace
-            let is_current = if ns == "all" {
-                current_namespace.is_none()
-            } else {
-                current_namespace.as_ref() == Some(ns)
-            };
-            let label = if is_current {
-                format!("NS:{}*", display_ns)
-            } else {
-                format!("NS:{}", display_ns)
-            };
-            nav_segments.push((key, label, theme.footer_key));
-        }
-    }
+    let nav_segments = navigation_commands_to_segments(&commands, theme.footer_key);
 
     // Build wrapped lines similar to header logic
     // Wrap footer content into 2 lines to prevent overflow

--- a/src/tui/views/header.rs
+++ b/src/tui/views/header.rs
@@ -28,7 +28,6 @@ pub fn render_header(
     read_only: bool,             // Readonly mode status
     theme: &Theme,
     no_icons: bool,
-    namespace_hotkeys: &[String],
 ) {
     // Split header into left (info), middle (controller status), and right (ASCII art)
     let header_chunks = Layout::default()
@@ -180,43 +179,6 @@ pub fn render_header(
                 .fg(theme.status_error)
                 .add_modifier(Modifier::BOLD),
         ));
-    }
-
-    // Add namespace hotkeys after namespace
-    if !namespace_hotkeys.is_empty() {
-        context_line_spans.push(Span::raw("  "));
-        for (idx, ns) in namespace_hotkeys.iter().enumerate() {
-            if idx > 0 {
-                context_line_spans.push(Span::raw(" "));
-            }
-            let display_ns = if ns == "all" {
-                "all"
-            } else if ns.len() > 6 {
-                &ns[..6]
-            } else {
-                ns
-            };
-            // Highlight current namespace
-            let is_current = if ns == "all" {
-                namespace.is_none()
-            } else {
-                namespace.as_ref() == Some(ns)
-            };
-            let hotkey_style = if is_current {
-                Style::default()
-                    .fg(theme
-                        .header_namespace_style(false)
-                        .fg
-                        .unwrap_or(theme.text_primary))
-                    .add_modifier(Modifier::BOLD)
-            } else {
-                Style::default().fg(theme.text_secondary)
-            };
-            context_line_spans.push(Span::styled(
-                format!("{}:{}", idx, display_ns),
-                hotkey_style,
-            ));
-        }
     }
 
     let mut header_lines = vec![Line::from(context_line_spans)];

--- a/src/tui/views/help.rs
+++ b/src/tui/views/help.rs
@@ -50,6 +50,7 @@ pub fn render_help(f: &mut Frame, area: Rect, theme: &Theme, namespace_hotkeys: 
         (":ctx <n>", "Switch context"),
         (":ctx", "Open context submenu"),
         (":ns <n>", "Switch namespace"),
+        (":ns", "Open namespace picker"),
         (":ns all", "Show all namespaces"),
         (":all", "Show all resources"),
         (":healthy", "Show healthy resources"),

--- a/tests/snapshot_tests.rs
+++ b/tests/snapshot_tests.rs
@@ -133,7 +133,6 @@ fn test_render_header() {
                 false,
                 &theme,
                 config.ui.no_icons,
-                &[],
             );
         })
         .unwrap();
@@ -168,7 +167,6 @@ fn test_render_header_with_namespace() {
                 false,
                 &theme,
                 config.ui.no_icons,
-                &[],
             );
         })
         .unwrap();
@@ -203,7 +201,6 @@ fn test_render_header_with_filter() {
                 false,
                 &theme,
                 config.ui.no_icons,
-                &[],
             );
         })
         .unwrap();
@@ -239,8 +236,6 @@ fn test_render_footer_navigation() {
                 &operation_registry,
                 &state,
                 &theme,
-                &[],
-                &None,
                 false,
             );
         })
@@ -276,8 +271,6 @@ fn test_render_footer_command_mode() {
                 &operation_registry,
                 &state,
                 &theme,
-                &[],
-                &None,
                 false,
             );
         })
@@ -313,8 +306,6 @@ fn test_render_footer_filter_mode() {
                 &operation_registry,
                 &state,
                 &theme,
-                &[],
-                &None,
                 false,
             );
         })
@@ -768,8 +759,6 @@ fn test_render_footer_connection_error() {
                 &operation_registry,
                 &state,
                 &theme,
-                &[],
-                &None,
                 true, // has_connection_error = true
             );
         })


### PR DESCRIPTION
## Summary

Replaces the cramped, hard-to-use namespace hotkey strips in the top and bottom bars with a searchable namespace **picker submenu**, reusing the same well-tested pattern as `:ctx` and `:skin`.

The old header (`0:all 1:flux-s 2:ce…`) and footer (`0 NS:all | 1 NS:…`) hotkey segments were noisy and, on most terminals, effectively unusable. Namespace switching is now driven by the `:ns` command, and the hotkeys stay discoverable in the help overlay.

## Changes

**Namespace picker**
- `:ns` / `:namespace` (no arg) → opens a searchable picker submenu (`/` filter, `j/k` navigate, `Enter` select, `Esc` cancel). `all` is always first; the current namespace is marked `(current)`.
- `:ns <name>` / `:namespace <name>` → switches directly, no picker.
- `:ns all` / `:ns -A` → cluster-wide scope (unchanged).
- New `namespace_submenu()` builder in `commands.rs` and `App::namespace_picker_options()` sourcing the list from the discovered/configured hotkey namespaces + the active namespace.
- Namespace-switch logic extracted into a shared `App::switch_namespace()` helper, reused by both the `:ns <name>` path and the submenu's `Enter` handler.

**Removed from the bars**
- Top header no longer renders the namespace hotkey strip.
- Bottom footer no longer renders the `NS:` segments; `calculate_footer_height` updated to match so layout caching stays consistent.
- Dropped the now-unused `MAX_FOOTER_NAMESPACE_HOTKEYS` / `MAX_FOOTER_NAMESPACE_LENGTH` constants.

**Kept**
- Number keys `0–9` still switch namespaces, and the `?` help overlay still shows the live "Namespace Hotkeys" column — so the dynamic help stays intact, just uncluttered from the bars. Added a `:ns → Open namespace picker` row to the help's GENERAL column.

**Docs**
- Documented `:ns` picker in the user guide and configuration pages.
- Added a blurb + link noting flux9s is listed as a community UI in the [Flux ecosystem](https://fluxcd.io/ecosystem/#flux-uis--guis), in both the README and docs home page.

## Notes

- For `:ns <name>` I kept the existing direct-switch behavior rather than hard-validating existence: namespace discovery only finds namespaces with Flux resources (and can be stale), so blocking a typed name risked false negatives on a valid target. The list simply shows empty if nothing is there; the picker is the discoverable, validated path.

## Testing

- New unit tests: `namespace_submenu` (current/`all` marking), `:ns` picker open + select flow, and direct `:ns <name>` switching.
- `just ci` passes (fmt, clippy, tests). Snapshot tests updated for the new `render_header` / `render_footer` signatures.

Signed-off-by: Daniel Guns <danbguns@gmail.com>
