### PR TITLE
open source update - security

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owner for everything in the repo. Required-review routing once branch
+# protection is enabled on `main`; also an OpenSSF Scorecard Code-Review signal.
+* @dgunzy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,10 +55,21 @@ jobs:
           fi
 
       - name: Run cargo-audit (CVE scan)
-        run: cargo audit --ignore RUSTSEC-2024-0436
+        run: cargo audit
 
       - name: Run tests
         run: cargo test --lib --tests
+
+  deny:
+    name: cargo-deny (licenses, advisories, bans, sources)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Run cargo-deny
+        uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
+        with:
+          command: check advisories bans licenses sources
 
   msrv:
     # Guards the rust-version declared in Cargo.toml: the crate must keep

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+  schedule:
+    - cron: "0 9 * * 1" # Monday 09:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (rust)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload results to code scanning
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # CodeQL's Rust extractor runs without compiling the crate, so no
+      # toolchain/build step is needed here (build-mode: none).
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        with:
+          languages: rust
+          build-mode: none
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        with:
+          category: "/language:rust"

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -1,0 +1,72 @@
+# Auto-merge Dependabot PRs once all required status checks pass.
+#
+#   - patch / minor updates -> enable auto-merge (squash). GitHub merges once
+#                              every required check on `main` is green.
+#   - major updates         -> left OPEN with a comment, for manual review.
+#
+# Fail-safe: this workflow only ever *enables* auto-merge; GitHub's branch
+# protection is what actually gates the merge on CI / cargo-deny / CodeQL. If
+# anything here errors, the PR is simply left open.
+#
+# One-time repo settings this depends on (not code — see ROADMAP.md):
+#   1. Settings > General > "Allow auto-merge" .......................... ENABLED
+#   2. Branch protection on `main` with required status checks.
+#   3. Settings > Actions > General > Workflow permissions:
+#      "Allow GitHub Actions to create and approve pull requests" ....... ENABLED
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Elevated so the auto-injected GITHUB_TOKEN can enable auto-merge / comment.
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: dependabot-automerge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  auto-merge:
+    name: Enable auto-merge
+    runs-on: ubuntu-latest
+    # Gate on the PR author (stays 'dependabot[bot]' for the PR's life), not
+    # github.actor (flips to a human on any push/merge to the branch).
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Satisfy the branch-protection "1 approving review" gate for bot PRs. The
+      # Actions token (github-actions[bot]) is a different identity from the PR
+      # author (dependabot[bot]), so this approval is valid. Requires the repo
+      # setting "Allow GitHub Actions to create and approve pull requests".
+      # This is NOT a merge — every required status check (CI, cargo-deny,
+      # CodeQL) still has to pass before GitHub actually merges.
+      - name: Approve patch/minor updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch/minor updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment on major updates (leave open for review)
+        if: steps.meta.outputs.update-type == 'version-update:semver-major'
+        run: |
+          gh pr comment "$PR_URL" --body \
+            "🚧 Major version bump for \`${{ steps.meta.outputs.dependency-names }}\` — left open for manual review (auto-merge only applies to patch/minor)."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,35 @@
+# Secret scanning with gitleaks. Complements GitHub-native secret scanning +
+# push protection (enabled in repo settings) by scanning PR/commit history.
+# No GITLEAKS_LICENSE is required on a personal (non-org) repository.
+name: gitleaks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1" # Monday 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gitleaks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    name: Scan for secrets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0 # full history so historical commits are scanned
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,7 +197,9 @@ jobs:
     needs: [build-unix, build-windows, publish]
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write # create the release + upload assets
+      id-token: write # cosign keyless signing + provenance (OIDC)
+      attestations: write # store build-provenance attestations
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -223,10 +225,51 @@ jobs:
         with:
           path: artifacts
 
+      # Flatten the per-artifact subdirectories download-artifact creates so the
+      # release assets, checksums, and signatures all live in one dir.
+      - name: Collect release assets
+        id: assets
+        run: |
+          mkdir -p dist
+          find artifacts -type f \( -name '*.tar.gz' -o -name '*.zip' \) -exec cp {} dist/ \;
+          cd dist
+          sha256sum * > SHA256SUMS
+          echo "Assets:" && ls -la
+
+      - name: Generate SBOM (CycloneDX)
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: .
+          format: cyclonedx-json
+          output-file: dist/flux9s-${{ steps.get_version.outputs.version }}.cdx.json
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      # Keyless signing of the checksum file: one signature covers every asset.
+      # Verify with:
+      #   cosign verify-blob --certificate SHA256SUMS.pem --signature SHA256SUMS.sig \
+      #     --certificate-identity-regexp 'https://github.com/dgunzy/flux9s/.+' \
+      #     --certificate-oidc-issuer https://token.actions.githubusercontent.com SHA256SUMS
+      - name: Sign checksums (cosign keyless)
+        run: |
+          cd dist
+          cosign sign-blob --yes \
+            --output-signature SHA256SUMS.sig \
+            --output-certificate SHA256SUMS.pem \
+            SHA256SUMS
+
+      # SLSA build provenance for each binary archive. Verify with:
+      #   gh attestation verify <archive> --repo dgunzy/flux9s
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: "dist/*.tar.gz, dist/*.zip"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v2
         with:
-          files: artifacts/**/*
+          files: dist/*
           generate_release_notes: true
           tag_name: ${{ steps.get_version.outputs.tag }}
           name: Release ${{ steps.get_version.outputs.version }}

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,34 @@
+# Scheduled CycloneDX SBOM of the dependency graph, kept as a 90-day artifact.
+# Release SBOMs are generated + attached separately in release.yml; this catches
+# new advisories in the dependency tree between releases.
+name: SBOM
+
+on:
+  schedule:
+    - cron: "0 2 * * *" # daily 02:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sbom:
+    name: Generate SBOM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Generate SBOM (CycloneDX)
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: .
+          format: cyclonedx-json
+          output-file: flux9s.cdx.json
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sbom
+          path: flux9s.cdx.json
+          retention-days: 90

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,58 @@
+name: OpenSSF Scorecard
+
+on:
+  # Re-run when branch protection changes (a graded Scorecard check).
+  branch_protection_rule:
+  # Weekly, plus on pushes that touch security-relevant files.
+  schedule:
+    - cron: "0 3 * * 1" # Monday 03:00 UTC
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "deny.toml"
+  workflow_dispatch:
+
+# Read-only by default; the analysis job elevates only what it needs.
+permissions: read-all
+
+concurrency:
+  group: scorecard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Upload results to the code-scanning dashboard.
+      security-events: write
+      # Publish results to the OpenSSF API (needed for the badge).
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publishes to the OpenSSF API so the README badge resolves.
+          publish_results: true
+
+      - name: Upload SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        with:
+          sarif_file: results.sarif
+
+      - name: Upload SARIF as artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 90

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A [K9s](https://github.com/derailed/k9s)-inspired terminal UI for monitoring Flux GitOps resources in real-time.
 
 [![CI](https://img.shields.io/github/actions/workflow/status/dgunzy/flux9s/ci.yml?branch=main&logo=github&label=CI)](https://github.com/dgunzy/flux9s/actions/workflows/ci.yml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/dgunzy/flux9s/badge)](https://scorecard.dev/viewer/?uri=github.com/dgunzy/flux9s)
 [![Crates.io](https://img.shields.io/crates/v/flux9s?logo=rust&color=blue)](https://crates.io/crates/flux9s)
 [![Downloads](https://img.shields.io/crates/d/flux9s?logo=rust&label=downloads)](https://crates.io/crates/flux9s)
 [![License](https://img.shields.io/github/license/dgunzy/flux9s?color=green)](LICENSE)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,4 +24,30 @@ sends cluster data anywhere else. Areas of particular interest for reports:
 - Credential handling around kubeconfig, exec plugins, and proxies
 - The release pipeline and published artifacts (crates.io, Homebrew, binstall)
 
-Dependency advisories are monitored via `cargo audit` in CI and Dependabot.
+Dependency advisories are monitored via `cargo audit` and `cargo deny` in CI, plus
+Dependabot. The build also runs OpenSSF Scorecard, CodeQL, and gitleaks.
+
+## Verifying releases
+
+Every release ships a `SHA256SUMS` file, a cosign signature over it, and SLSA
+build-provenance attestations for each archive.
+
+Verify the checksums are authentic (cosign keyless):
+
+```bash
+cosign verify-blob \
+  --certificate SHA256SUMS.pem \
+  --signature SHA256SUMS.sig \
+  --certificate-identity-regexp 'https://github.com/dgunzy/flux9s/.+' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  SHA256SUMS
+sha256sum -c SHA256SUMS
+```
+
+Verify build provenance for a downloaded archive:
+
+```bash
+gh attestation verify flux9s-linux-x86_64-musl.tar.gz --repo dgunzy/flux9s
+```
+
+A CycloneDX SBOM (`*.cdx.json`) is attached to each release.

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,50 @@
+# cargo-deny configuration — supply-chain policy for flux9s.
+# Supersedes bare `cargo audit`: advisories + licenses + banned/duplicate
+# crates + source allow-listing. Run locally with `cargo deny check`.
+# Docs: https://embarkstudios.github.io/cargo-deny/
+
+[graph]
+all-features = true
+
+[advisories]
+version = 2
+# No ignores currently: the graph is clean (the former RUSTSEC-2024-0436 `paste`
+# ignore is gone now that `paste` dropped out of the dependency tree). Add IDs
+# here — with a comment and a revisit note — only when unavoidable.
+ignore = []
+
+[licenses]
+version = 2
+confidence-threshold = 0.9
+# Every dependency license in the current graph is OSI-permissive. Keep this
+# list tight: a new dependency under an unlisted license fails CI on purpose,
+# which is the signal to review it before it ships.
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "MIT",
+    "ISC",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "Zlib",
+    "0BSD",
+    "Unlicense",
+    "CC0-1.0",
+    "BSL-1.0",
+    "Unicode-3.0",
+    "MPL-2.0",
+    "CDLA-Permissive-2.0",
+]
+
+[bans]
+# Duplicate versions bloat the binary; warn rather than fail (the kube/k8s graph
+# legitimately pulls a few). Wildcard version requirements are a real smell.
+multiple-versions = "warn"
+wildcards = "deny"
+# Allow wildcards on path/git deps within the workspace (there are none today).
+allow-wildcard-paths = true
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
## Summary

Supply-chain & security hardening for the 1.0.0 push, from external OSS-readiness
feedback (OpenSSF / CodeQL / auto-dependabot). Benchmarked against
[firestoned/bindy](https://github.com/firestoned/bindy); container-only controls
were intentionally skipped since flux9s ships a CLI binary. All new Actions are
SHA-pinned.

## Changes

**New workflows**
- `scorecard.yml` — OpenSSF Scorecard (weekly + `branch_protection_rule` + push),
  SARIF → code scanning, `publish_results` for the badge.
- `codeql.yml` — CodeQL for Rust (`build-mode: none`), push/PR/weekly.
- `dependabot-auto-merge.yaml` — auto-approve + auto-merge patch/minor, majors left
  open. Bot approval clears the review gate; required checks still gate the merge.
- `sbom.yml` — daily CycloneDX SBOM artifact.
- `gitleaks.yml` — secret scanning on PR/push/weekly.

**Config / policy**
- `deny.toml` + a `deny` job in `ci.yml` — cargo-deny (advisories + permissive
  license allow-list + bans + sources). Dropped the now-stale RUSTSEC-2024-0436
  ignore (`paste` left the graph); `cargo audit` runs clean.
- `.github/CODEOWNERS` — advisory owner routing / Scorecard Code-Review signal.

**Releases (`release.yml`)**
- Emit `SHA256SUMS`, sign it with Sigstore cosign (keyless → `.sig` + `.pem`),
  attest SLSA build provenance, and attach a CycloneDX SBOM. Verification recipe
  added to `SECURITY.md`.

**Docs**
- README OpenSSF Scorecard badge; SECURITY.md cosign / `gh attestation verify`
  instructions.

## Repo settings (applied out-of-band via `gh api`)

Branch protection on `main` (3 required checks, 1 review, dismiss-stale-reviews,
linear history, no force-push); allow auto-merge; Actions may approve PRs; secret
scanning + push protection; Dependabot security updates. `enforce_admins: false`
(solo-maintainer bypass) and `require_code_owner_reviews: false` (any contributor
can review) are intentional.

## Verification

- `cargo deny check` → ok (advisories/bans/licenses/sources); `cargo audit` clean.
- All workflow YAML validated. Scorecard/CodeQL/gitleaks run on this PR; next
  tagged release exercises signing, provenance, and SBOM attachment.

Signed-off-by: Daniel Guns <danbguns@gmail.com>
