### PR TITLE
cosign fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,11 +192,20 @@ jobs:
         with:
           toolchain: stable
 
+      # Idempotent: crates.io versions are immutable, so a re-run for a version
+      # that's already published (e.g. finishing a release whose signing step
+      # failed) skips publish instead of failing the whole workflow.
       - name: Publish to crates.io
         env:
           CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
         run: |
-          cargo publish --token $CRATES_IO_TOKEN
+          VERSION=$(grep '^version = ' Cargo.toml | head -1 | cut -d'"' -f2)
+          if curl -sf -H "User-Agent: flux9s-release-ci" \
+               "https://crates.io/api/v1/crates/flux9s/${VERSION}" >/dev/null; then
+            echo "flux9s ${VERSION} is already on crates.io — skipping publish."
+          else
+            cargo publish --token "$CRATES_IO_TOKEN"
+          fi
 
   release:
     name: Create GitHub Release
@@ -252,17 +261,17 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
-      # Keyless signing of the checksum file: one signature covers every asset.
-      # Verify with:
-      #   cosign verify-blob --certificate SHA256SUMS.pem --signature SHA256SUMS.sig \
+      # Keyless signing of the checksum file: one bundle covers every asset.
+      # cosign v3 replaced --output-signature/--output-certificate with a single
+      # Sigstore --bundle (signature + cert + Rekor entry in one JSON). Verify:
+      #   cosign verify-blob --bundle SHA256SUMS.cosign.bundle \
       #     --certificate-identity-regexp 'https://github.com/dgunzy/flux9s/.+' \
       #     --certificate-oidc-issuer https://token.actions.githubusercontent.com SHA256SUMS
       - name: Sign checksums (cosign keyless)
         run: |
           cd dist
           cosign sign-blob --yes \
-            --output-signature SHA256SUMS.sig \
-            --output-certificate SHA256SUMS.pem \
+            --bundle SHA256SUMS.cosign.bundle \
             SHA256SUMS
 
       # SLSA build provenance for each binary archive. Verify with:

--- a/.github/workflows/signing-smoke-test.yml
+++ b/.github/workflows/signing-smoke-test.yml
@@ -1,0 +1,40 @@
+# Validates the cosign keyless sign+verify round-trip used by release.yml,
+# WITHOUT publishing or tagging anything. Run it on demand before cutting a
+# release; it also self-checks whenever the release/signing workflows change.
+name: Signing smoke test
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/release.yml"
+      - ".github/workflows/signing-smoke-test.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  cosign-roundtrip:
+    name: cosign sign + verify (dummy blob)
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # keyless OIDC — same as the release job
+    steps:
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      # Mirrors the exact sign invocation in release.yml, then verifies it, so a
+      # broken cosign flag/version fails HERE instead of mid-release.
+      - name: Sign + verify a dummy checksum file
+        run: |
+          echo "flux9s signing smoke test $(date -u)" > SHA256SUMS
+          cosign sign-blob --yes \
+            --bundle SHA256SUMS.cosign.bundle \
+            SHA256SUMS
+          cosign verify-blob \
+            --bundle SHA256SUMS.cosign.bundle \
+            --certificate-identity-regexp "https://github.com/${GITHUB_REPOSITORY}/.+" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            SHA256SUMS
+          echo "✓ cosign sign + verify round-trip OK"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,15 +29,14 @@ Dependabot. The build also runs OpenSSF Scorecard, CodeQL, and gitleaks.
 
 ## Verifying releases
 
-Every release ships a `SHA256SUMS` file, a cosign signature over it, and SLSA
-build-provenance attestations for each archive.
+Every release ships a `SHA256SUMS` file, a cosign Sigstore bundle over it
+(`SHA256SUMS.cosign.bundle`), and SLSA build-provenance attestations for each archive.
 
 Verify the checksums are authentic (cosign keyless):
 
 ```bash
 cosign verify-blob \
-  --certificate SHA256SUMS.pem \
-  --signature SHA256SUMS.sig \
+  --bundle SHA256SUMS.cosign.bundle \
   --certificate-identity-regexp 'https://github.com/dgunzy/flux9s/.+' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   SHA256SUMS


### PR DESCRIPTION
Fixes the release signing that failed on cosign v3 (v1.0.0 run
[30121135723](https://github.com/dgunzy/flux9s/actions/runs/30121135723)).

- **`release.yml` sign step** → cosign v3 `--bundle SHA256SUMS.cosign.bundle`
  (v3 dropped `--output-signature`/`--output-certificate`).
- **crates.io publish is now idempotent** — skips if the version already exists, so
  a release can be safely re-run for an already-published version (e.g. finishing v1.0.0).
- **`signing-smoke-test.yml`** — `workflow_dispatch` job that sign+verify round-trips a
  dummy blob, to validate cosign in CI without cutting a release.
- **`SECURITY.md`** verify recipe updated to `--bundle`.

Signed-off-by: Daniel Guns <danbguns@gmail.com>
