### PR TITLE
edit refinement, drop null fields

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -674,8 +674,11 @@ pub async fn run_tui_with_async_init(
                 app.async_state.edit_editor_launched = true;
 
                 if let Some(full_yaml_json) = app.async_state.edit_full_yaml.take() {
+                    // Present the same trimmed document the YAML view shows, not the
+                    // raw API response (no managedFields, no status, no explicit nulls).
+                    let edit_doc = crate::tui::views::prepare_edit_document(&full_yaml_json);
                     let yaml_str =
-                        serde_yaml::to_string(&full_yaml_json).unwrap_or_else(|_| "{}".to_string());
+                        serde_yaml::to_string(&edit_doc).unwrap_or_else(|_| "{}".to_string());
                     let editor_candidates =
                         crate::editor::editor_candidates(app.config.editor.as_deref());
                     let enable_mouse = app.config.ui.enable_mouse;

--- a/src/tui/views/helpers.rs
+++ b/src/tui/views/helpers.rs
@@ -71,6 +71,44 @@ pub fn clean_resource_json(obj: &serde_json::Value) -> serde_json::Value {
     }
 }
 
+/// Recursively drop object entries whose value is `null`.
+///
+/// Explicit nulls are noise in a text view and, in an edit buffer, are read by
+/// Server Side Apply as "delete this field" — neither is what the user means.
+pub fn strip_null_fields(obj: &serde_json::Value) -> serde_json::Value {
+    match obj {
+        serde_json::Value::Object(map) => {
+            let mut cleaned = serde_json::Map::new();
+            for (key, value) in map {
+                if value.is_null() {
+                    continue;
+                }
+                cleaned.insert(key.clone(), strip_null_fields(value));
+            }
+            serde_json::Value::Object(cleaned)
+        }
+        serde_json::Value::Array(arr) => {
+            serde_json::Value::Array(arr.iter().map(strip_null_fields).collect())
+        }
+        other => other.clone(),
+    }
+}
+
+/// Build the document handed to the external editor.
+///
+/// The raw API response carries bookkeeping the user cannot usefully edit, so
+/// this mirrors what `kubectl get -o yaml` shows instead: `metadata.managedFields`
+/// and the server-owned `status` are dropped, along with explicit nulls.
+/// `metadata.resourceVersion` is deliberately kept — the SSA apply needs it for
+/// optimistic locking.
+pub fn prepare_edit_document(obj: &serde_json::Value) -> serde_json::Value {
+    let mut doc = strip_null_fields(&clean_resource_json(obj));
+    if let Some(map) = doc.as_object_mut() {
+        map.remove("status");
+    }
+    doc
+}
+
 /// Render an empty state message
 ///
 /// Shows a consistent empty state message across all views.
@@ -162,6 +200,59 @@ mod tests {
         assert_eq!(format_age(Some(Utc::now() - Duration::hours(3))), "3h");
         assert_eq!(format_age(Some(Utc::now() - Duration::days(12))), "12d");
         assert_eq!(format_age(Some(Utc::now() - Duration::days(800))), "2y");
+    }
+
+    #[test]
+    fn test_strip_null_fields_removes_nulls_recursively() {
+        let value = serde_json::json!({
+            "spec": {
+                "path": "./apps",
+                "postBuild": null,
+                "sourceRef": { "kind": "GitRepository", "namespace": null },
+                "dependsOn": [{ "name": "configs", "namespace": null }]
+            }
+        });
+        let cleaned = strip_null_fields(&value);
+        assert_eq!(
+            cleaned,
+            serde_json::json!({
+                "spec": {
+                    "path": "./apps",
+                    "sourceRef": { "kind": "GitRepository" },
+                    "dependsOn": [{ "name": "configs" }]
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn test_prepare_edit_document_drops_managed_fields_status_and_nulls() {
+        let value = serde_json::json!({
+            "apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+            "kind": "Kustomization",
+            "metadata": {
+                "name": "apps",
+                "namespace": "flux-system",
+                "resourceVersion": "69913306",
+                "deletionTimestamp": null,
+                "managedFields": [{ "manager": "kustomize-controller" }]
+            },
+            "spec": { "path": "./apps", "prune": true },
+            "status": { "observedGeneration": 7 }
+        });
+
+        let doc = prepare_edit_document(&value);
+        let meta = doc.get("metadata").and_then(|m| m.as_object()).unwrap();
+
+        assert!(doc.get("status").is_none(), "status must be dropped");
+        assert!(meta.get("managedFields").is_none());
+        assert!(meta.get("deletionTimestamp").is_none());
+        // resourceVersion is required for the SSA optimistic-locking check
+        assert_eq!(
+            meta.get("resourceVersion").and_then(|v| v.as_str()),
+            Some("69913306")
+        );
+        assert_eq!(doc.get("spec"), value.get("spec"));
     }
 
     #[test]

--- a/src/tui/views/yaml.rs
+++ b/src/tui/views/yaml.rs
@@ -122,8 +122,12 @@ pub fn render_resource_yaml(
         }
     };
 
-    // Clean the JSON object to remove Kubernetes internal fields
-    let cleaned_json = crate::tui::views::helpers::clean_resource_json(&obj_json);
+    // Clean the JSON object to remove Kubernetes internal fields. Nulls are also
+    // dropped — the fallback path serializes typed models, which emit every unset
+    // optional field as `null`.
+    let cleaned_json = crate::tui::views::helpers::strip_null_fields(
+        &crate::tui::views::helpers::clean_resource_json(&obj_json),
+    );
 
     // Convert JSON to YAML using serde_yaml with proper formatting
     // serde_yaml automatically handles indentation with spaces


### PR DESCRIPTION
## What

The `e` (edit) flow opened a temp YAML containing the entire raw API object — `metadata.managedFields` with every `fieldsV1` entry, the server-owned `status` block, and explicit nulls — instead of the `kubectl get -o yaml`-style document users expect.

Two paths render the same object and only one cleaned it: the YAML view ran `clean_resource_json()` (strips `managedFields`), while the edit path serialized the raw fetched `DynamicObject` straight to the temp file with no cleaning at all.

## Changes

- `src/tui/views/helpers.rs`: add `strip_null_fields()` (recursive null-entry removal) and `prepare_edit_document()` (drops `managedFields` + `status` + nulls, **keeps `metadata.resourceVersion`** — the SSA apply needs it for the 409 optimistic-locking check).
- `src/tui/mod.rs`: edit path runs the document through `prepare_edit_document()` before writing the temp file.
- `src/tui/views/yaml.rs`: also strips nulls, so the view and the editor show the same thing. Its fallback path serializes typed models, which emit every unset optional as `null`.

## Why

- `kubectl` hides `managedFields` client-side, so the raw API response looked nothing like what users see from `kubectl get -o yaml`. Confirmed via `kubectl get --raw` that the live object really does carry `managedFields` plus a 7-key `status` — flux9s was faithfully showing server noise.
- Explicit nulls are not just visual noise: Server Side Apply reads them as "delete this field", so they were a real hazard in an edit buffer.
- Dropping `status` is safe: Flux CRDs have a status subresource, so the API server ignores status on a main-resource apply, and flux9s never owned status fields — nothing gets pruned. This differs from `kubectl edit`, which keeps status, but status is not editable there and made up a large share of the noise.

## Tests

`just ci` green. Two new unit tests: `test_strip_null_fields_removes_nulls_recursively` and `test_prepare_edit_document_drops_managed_fields_status_and_nulls` (asserts `resourceVersion` survives the cleaning).

Signed-off-by: Daniel Guns <danbguns@gmail.com>
