### PR TITLE
pin docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,13 +32,20 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@2752ce1d29631191ea3f27c23495fa06139a5b78 # v3.2.1
         with:
-          hugo-version: 'latest'
+          # Pinned, not 'latest': a breaking Hugo release must not be able to
+          # break the docs build unannounced. Dependabot cannot track an action
+          # input, so bump this by hand alongside the docsy pin in docs/go.mod
+          # (docsy documents the Hugo versions it supports per release).
+          hugo-version: '0.164.0'
           extended: true
 
       - name: Setup Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '1.21'
+          # The Go module lives in docs/, not the repo root — without this the
+          # cache step warns "Dependencies file is not found" and never caches.
+          cache-dependency-path: docs/go.sum
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -49,9 +56,14 @@ jobs:
 
       - name: Install Go dependencies
         working-directory: docs
-        run: |
-          go mod download
-          go mod tidy
+        # No `go mod tidy` here: docsy is a Hugo theme module that no Go code
+        # imports, so tidy drops the require line and Hugo then silently
+        # resolves the theme to the latest release. That is how docsy v0.16.0
+        # (which moved layouts into a nested module) broke this build.
+        # -mod=readonly makes any attempt to change the pin fail loudly instead.
+        env:
+          GOFLAGS: -mod=readonly
+        run: go mod download
 
       - name: Install npm dependencies
         working-directory: docs
@@ -71,6 +83,10 @@ jobs:
 
       - name: Build Hugo site
         working-directory: docs
+        # Hugo resolves the theme module itself, so it too must not be allowed
+        # to move the docsy pin recorded in docs/go.mod.
+        env:
+          GOFLAGS: -mod=readonly
         run: |
           hugo --minify --baseURL "https://flux9s.ca/"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,6 +218,17 @@ Commands can provide interactive selection menus using the `CommandSubmenu` trai
   # then bump every dtolnay/rust-toolchain@<old> to @$sha across .github/workflows/
   ```
   Open a PR so CI validates the bump before it lands.
+- **Docs-site toolchain pins are also hand-managed.** Two more things Dependabot
+  cannot track, both in `.github/workflows/docs.yml` / `docs/go.mod`:
+  - `hugo-version: '0.164.0'` — an action *input*, invisible to Dependabot.
+  - `require github.com/google/docsy vX.Y.Z` in `docs/go.mod` — the Hugo theme is
+    referenced only from `docs/config.toml`, so **`go mod tidy` deletes the
+    require line** and Hugo then floats the theme to its latest release. Never
+    run `go mod tidy` in `docs/`; the workflow sets `GOFLAGS: -mod=readonly` so
+    a lost pin fails loudly instead of silently upgrading.
+
+  Bump the two together (docsy documents its supported Hugo versions per
+  release) and let the docs workflow validate it in a PR.
 - **Rust deps**: `cargo audit` + `cargo deny` gate CI; keep `deny.toml`'s license
   allow-list tight (a new license fails CI on purpose — review before allowing).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,6 +218,17 @@ Commands can provide interactive selection menus using the `CommandSubmenu` trai
   # then bump every dtolnay/rust-toolchain@<old> to @$sha across .github/workflows/
   ```
   Open a PR so CI validates the bump before it lands.
+- **Docs-site toolchain pins are also hand-managed.** Two more things Dependabot
+  cannot track, both in `.github/workflows/docs.yml` / `docs/go.mod`:
+  - `hugo-version: '0.164.0'` — an action *input*, invisible to Dependabot.
+  - `require github.com/google/docsy vX.Y.Z` in `docs/go.mod` — the Hugo theme is
+    referenced only from `docs/config.toml`, so **`go mod tidy` deletes the
+    require line** and Hugo then floats the theme to its latest release. Never
+    run `go mod tidy` in `docs/`; the workflow sets `GOFLAGS: -mod=readonly` so
+    a lost pin fails loudly instead of silently upgrading.
+
+  Bump the two together (docsy documents its supported Hugo versions per
+  release) and let the docs workflow validate it in a PR.
 - **Rust deps**: `cargo audit` + `cargo deny` gate CI; keep `deny.toml`'s license
   allow-list tight (a new license fails CI on purpose — review before allowing).
 

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -2,4 +2,15 @@ module github.com/dgunzy/flux9s/docs
 
 go 1.21
 
-require github.com/google/docsy v0.13.0 // indirect
+// Hugo theme module, pinned deliberately. Nothing here imports docsy from Go
+// code — it is referenced only by `theme = ['github.com/google/docsy']` in
+// config.toml — so `go mod tidy` DELETES this line, after which Hugo resolves
+// the theme to whatever the latest release happens to be. Do not run
+// `go mod tidy` in this module (see .github/workflows/docs.yml).
+//
+// Do not bump to v0.16.0 as-is: that release moved the theme into a nested
+// module, so layouts no longer live at the module root and every shortcode
+// fails to resolve. Upgrading means switching the path to
+// github.com/google/docsy/theme (tagged theme/v0.16.0) and following the
+// docsy 0.16.0 upgrade guide (Bootstrap/Font Awesome now come from npm).
+require github.com/google/docsy v0.15.0

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -4,5 +4,7 @@ github.com/google/docsy v0.8.0 h1:RgHyKRTo8YwScMThrf01Ky2yCGpUS1hpkspwNv6szT4=
 github.com/google/docsy v0.8.0/go.mod h1:FqTNN2T7pWEGW8dc+v5hQ5VF29W5uaL00PQ1LdVw5F8=
 github.com/google/docsy v0.13.0 h1:Y1oy5SmQ0ikJJsvkuefEVZMj0MTXLmVfpXbt7Ytc7rc=
 github.com/google/docsy v0.13.0/go.mod h1:1Fj1W1O3esZh7IBQ8XAYtxtg10udBXuGI89+LUQc1AU=
+github.com/google/docsy v0.15.0 h1:MNJ1nrE2ZuweXlUNaegTo/UbSKZJu+WMczahfZaxosI=
+github.com/google/docsy v0.15.0/go.mod h1:1Fj1W1O3esZh7IBQ8XAYtxtg10udBXuGI89+LUQc1AU=
 github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
 github.com/twbs/bootstrap v5.3.8+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
## What

Fixes the docs build failure in [run 30543558736](https://github.com/dgunzy/flux9s/actions/runs/30543558736) (`failed to extract shortcode: template for shortcode "alert" not found`) and removes the floating dependencies that caused it.

## Why it broke

`docs/go.mod` declared `require github.com/google/docsy v0.13.0 // indirect`, but that was never actually a pin. docsy is referenced only by `theme = ['github.com/google/docsy']` in `docs/config.toml` — no Go code imports it — so the workflow's `go mod tidy` **deleted the require line** on every run (`go: warning: "all" matched no packages`). Hugo then resolved the theme to whatever the newest release was.

**docsy v0.16.0 was published 2026-07-29, one day before the failing run**, and it moved the theme into a nested module (`github.com/google/docsy/theme`, tag `theme/v0.16.0`). The module root no longer contains `layouts/`, so every shortcode failed to resolve. The run log shows it directly: `go: added github.com/google/docsy v0.16.0`.

Not transient, and it would fail on every re-run. The pin had been ignored for a long time — the last green run floated to v0.15.0, which still had root layouts.

## Changes

- `docs/go.mod`: pin docsy `v0.15.0` (what the currently deployed site was built with, so no rendering change), with a comment on the `tidy` trap and what a real v0.16.0 upgrade requires.
- `docs/go.sum`: add the v0.15.0 hashes.
- `.github/workflows/docs.yml`:
  - drop `go mod tidy`;
  - `GOFLAGS: -mod=readonly` on the dependency and Hugo build steps, so a lost pin fails loudly instead of silently upgrading;
  - pin `hugo-version: '0.164.0'` (was `'latest'` — the same class of floating dependency, and an action input Dependabot cannot track);
  - `cache-dependency-path: docs/go.sum` on `setup-go`, fixing the second annotation on that run (`Restore cache failed: Dependencies file is not found` — the module is in `docs/`, not the repo root).
- `CLAUDE.md` / `AGENTS.md`: document both hand-managed docs pins next to the existing "pins Dependabot can't track" guidance, and that they should be bumped together.

## Verification

Reproduced the failure locally, then built the real docs tree against the exact CI Hugo (0.164.0) with the pin in place: clean build, 19 pages, `go.mod` unchanged afterward. Two pre-existing non-fatal warnings remain (a `.Language.LanguageDirection` deprecation from docsy and `no layout file for "json" for kind "home"`).

Signed-off-by: Daniel Guns <danbguns@gmail.com>
