### PR TITLE
anchors on doc site

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,11 +6,12 @@ on:
     paths-ignore:
       - "**.md"
       - "docs/**"
+  # No paths filter on pull_request: "Analyze (rust)" is a required status check
+  # on main, and a workflow skipped by path filtering never reports its checks —
+  # they sit pending forever and the PR can never merge. Docs-only PRs pay ~1min
+  # for a build-mode:none scan. Matches ci.yml, which also filters push only.
   pull_request:
     branches: [main]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
   schedule:
     - cron: "0 9 * * 1" # Monday 09:00 UTC
   workflow_dispatch:

--- a/docs/layouts/_markup/render-heading.html
+++ b/docs/layouts/_markup/render-heading.html
@@ -1,0 +1,4 @@
+{{/* Enable Docsy's build-time heading self links (`#` anchor beside every
+     heading). Docsy ships the partial but leaves the render hook to the site.
+     See https://www.docsy.dev/docs/adding-content/navigation/#heading-self-links */}}
+{{ partial "td/render-heading.html" . }}


### PR DESCRIPTION
Signed-off-by: Daniel Guns <danbguns@gmail.com>

## What does this PR do?

Adds clickable `#` heading self-links to the docs site. Docsy ships the `td/render-heading.html` partial but leaves the render hook to the site, so headings had auto-generated IDs (TOC worked) but no visible anchor to click or copy. This adds the one-line hook that enables it.

Verified with a full build on the CI-pinned Hugo 0.164.0 — every markdown heading across all content pages now emits `<a class="td-heading-self-link">`. Landing page headings come from templates, not markdown, so they intentionally get none. No SCSS needed; Docsy's default style shows the `#` on hover (always visible on touch/small screens).

## Checklist

- [x] `just ci` passes locally (fmt, clippy, audit, tests)
- [x] Commits are signed off (`git commit -s`) — the DCO check requires it
- [ ] New behavior has tests — n/a, docs-site template only
- [x] User-facing changes update the help view, README, and docs site as applicable
